### PR TITLE
Feature - Created Editor Camera

### DIFF
--- a/Edge/Untitled.rzscn
+++ b/Edge/Untitled.rzscn
@@ -2,9 +2,9 @@ Scene: Untitled
 Entities:
   - Entity: 5
     Transform:
-      Position: [10, 0, -20]
-      Rotation: [0, 0, 0]
-      Scale: [0, 0, 0]
+      Position: [0, 0, -20]
+      Rotation: [0, 10, 0]
+      Scale: [0.0500000007, 0.0500000007, 0.0500000007]
   - Entity: 4
     Transform:
       Position: [0, 0, 0]
@@ -27,6 +27,6 @@ Entities:
       Scale: [0, 0, 0]
   - Entity: 0
     Transform:
-      Position: [0, 0, -20]
-      Rotation: [0, 10, 0]
-      Scale: [0.0500000007, 0.0500000007, 0.0500000007]
+      Position: [10, 0, -20]
+      Rotation: [0, 0, 0]
+      Scale: [0, 0, 0]

--- a/Edge/src/EditorCamera.cpp
+++ b/Edge/src/EditorCamera.cpp
@@ -1,0 +1,77 @@
+#include "EditorCamera.h"
+
+namespace EdgeEditor
+{
+	void EditorCamera::ProcessInput(float dt)
+	{
+		const float CameraSpeed = 5.0f * dt; // adjust accordingly
+		const glm::vec3 CameraFront = Camera.CameraFront;
+		const glm::vec3 CameraUp = Camera.CameraUp;
+
+		if (RazorIO::Get().GetStateForKey(RazorKey::W) == KEY_PRESSED)
+		{
+			Camera.CameraPos += CameraSpeed * CameraFront;
+		}
+		if (RazorIO::Get().GetStateForKey(RazorKey::S) == KEY_PRESSED)
+		{
+			Camera.CameraPos -= CameraSpeed * CameraFront;
+		}
+		if (RazorIO::Get().GetStateForKey(RazorKey::A) == KEY_PRESSED)
+		{
+			Camera.CameraPos -= glm::normalize(glm::cross(CameraFront, CameraUp)) * CameraSpeed;
+		}
+		if (RazorIO::Get().GetStateForKey(RazorKey::D) == KEY_PRESSED)
+		{
+			Camera.CameraPos += glm::normalize(glm::cross(CameraFront, CameraUp)) * CameraSpeed;
+		}
+
+		const Vector2D CurrentMouseCoords = RazorIO::Get().CurrentMousePos;
+		// Capture moment we click down
+		// Move us each update by the distance we have moved
+		// Capture moment we stop clicking
+		if (RazorIO::Get().GetStateForMouseButton(RazorMouseButton::RIGHT) == RazorMouseState::MOUSE_DOWN)
+		{
+			if (bIsFirstFrameDown)
+			{
+				MouseLastX = CurrentMouseCoords.X;
+				MouseLastY = CurrentMouseCoords.Y;
+				bIsFirstFrameDown = false;
+			}
+
+			if (MouseLastX != CurrentMouseCoords.X || MouseLastY != CurrentMouseCoords.Y)
+			{
+				RZ_CORE_INFO("MouseCoords: {0},{1}", CurrentMouseCoords.X, CurrentMouseCoords.Y);
+				RZ_CORE_INFO("LastMouseCoords: {0},{1}", MouseLastX, MouseLastY);
+				float Xoffset = RazorIO::Get().CurrentMousePos.X - MouseLastX;
+				float Yoffset = RazorIO::Get().CurrentMousePos.Y - MouseLastY;
+
+				const float MouseSensitivity = 0.1f;
+				Xoffset *= MouseSensitivity;
+				Yoffset *= MouseSensitivity;
+
+				Yaw += Xoffset;
+				Pitch += Yoffset;
+
+				Pitch = Pitch > 89.0f ? 89.0f : ((Pitch < -89.0f) ? -89.0f : Pitch);
+
+				Camera.CameraDirection.x = cos(glm::radians(Yaw)) * cos(glm::radians(Pitch));
+				Camera.CameraDirection.y = sin(glm::radians(Pitch));
+				Camera.CameraDirection.z = sin(glm::radians(Yaw)) * cos(glm::radians(Pitch));
+
+				MouseLastX = RazorIO::Get().CurrentMousePos.X;
+				MouseLastY = RazorIO::Get().CurrentMousePos.Y;
+			}
+			Camera.CameraFront = Camera.CameraDirection;
+		}
+
+		if (RazorIO::Get().GetStateForMouseButton(RazorMouseButton::RIGHT) == RazorMouseState::MOUSE_UP)
+		{
+			bIsFirstFrameDown = true;
+		}
+	}
+
+	Razor::Camera& EditorCamera::GetCamera()
+	{
+		return Camera;
+	}
+}

--- a/Edge/src/EditorCamera.h
+++ b/Edge/src/EditorCamera.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Razor.h"
+
+namespace EdgeEditor
+{
+	class EditorCamera
+	{
+	public:
+		void ProcessInput(float dt);
+
+		Razor::Camera& GetCamera();
+	private:
+		Razor::Camera Camera;
+
+		float MouseLastX = 400;
+		float MouseLastY = 300;
+		float Yaw = -90.0f;
+		float Pitch = 0.0f;
+		bool bIsFirstFrameDown = true;
+	};
+}
+

--- a/Edge/src/Systems/RSEditorCamera.cpp
+++ b/Edge/src/Systems/RSEditorCamera.cpp
@@ -1,0 +1,28 @@
+#include "RSEditorCamera.h"
+
+namespace EdgeEditor
+{
+
+	void RSEditorCamera::Render(Razor::RenderPipelineEntityProperties& EntityProperties)
+	{
+		const int SCREEN_WIDTH = 800;
+		const int SCREEN_HEIGHT = 600;
+
+		glm::mat4 CameraProjection = glm::perspective(glm::radians(45.0f), (float)SCREEN_WIDTH / (float)SCREEN_HEIGHT, 0.1f, 100.0f);
+		glm::mat4 CameraView = glm::lookAt(EditorCamera.CameraPos, EditorCamera.CameraPos + EditorCamera.CameraFront, EditorCamera.CameraUp);
+		for (auto& Pair : EntityProperties.Properties)
+		{
+			Razor::EntityRenderProperty& Property = Pair.second;
+			for (int j = 0; j < Property.GetNumberOfSlots(); j++)
+			{
+				Razor::PropertySlot& Slot = Property.GetPropertySlot(j);
+
+				Slot.AddProperty<glm::mat4>("projection", CameraProjection);
+				Slot.AddProperty<glm::mat4>("view", CameraView);
+				Slot.AddProperty<glm::vec3>("viewPos", EditorCamera.CameraPos);
+			}
+		}
+
+	}
+
+}

--- a/Edge/src/Systems/RSEditorCamera.h
+++ b/Edge/src/Systems/RSEditorCamera.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Razor.h"
+
+namespace EdgeEditor
+{
+	class RSEditorCamera : public Razor::RenderSystem
+	{
+	public:
+		RSEditorCamera(Razor::Ref<Razor::Scene> Scene, std::shared_ptr<Razor::IRenderer> Renderer, Razor::Camera& EditorCamera) 
+			: RenderSystem(Scene), Renderer(Renderer), EditorCamera(EditorCamera)
+		{
+			SystemRenderStage = Razor::RenderStage::RENDER_STAGE_CAMERA_PASS;
+		}
+		void Render(Razor::RenderPipelineEntityProperties& EntityProperties) override;
+
+	protected:
+		std::shared_ptr<Razor::IRenderer> Renderer;
+		Razor::Camera& EditorCamera;
+	};
+}
+


### PR DESCRIPTION
Problem:
We need a camera that is separate from the game that we can use to render the scene inside the editor

Solution:
Created a separate camera called EditorCamera alongside a separate pipeline config that uses that for the camera pass

Limits:
None

EdgeApp
*Added new pipeline config EditorPipelineConfig
*Registered new render system RSEditorCamera
*Replaced PipelineConfig with EditorPipelineConfig for rendering of scene 
*Removed Camera we were adding to the scene on load 
*Created ProcessInput function to deal with input

RSEditorCamera
*Created new class to deal with camera pass for editor pipeline config to allow manually passing in Camera to use rather than use entities

EditorCamera
*Created new class to hold editor camera functionality