### PR TITLE
Feature - Pickbuffer Links Properly To Viewport

### DIFF
--- a/Edge/Untitled.rzscn
+++ b/Edge/Untitled.rzscn
@@ -2,9 +2,9 @@ Scene: Untitled
 Entities:
   - Entity: 5
     Transform:
-      Position: [0, 0, -20]
-      Rotation: [0, 10, 0]
-      Scale: [0.0500000007, 0.0500000007, 0.0500000007]
+      Position: [10, 0, -20]
+      Rotation: [0, 0, 0]
+      Scale: [0, 0, 0]
   - Entity: 4
     Transform:
       Position: [0, 0, 0]
@@ -27,6 +27,6 @@ Entities:
       Scale: [0, 0, 0]
   - Entity: 0
     Transform:
-      Position: [10, 0, -20]
-      Rotation: [0, 0, 0]
-      Scale: [0, 0, 0]
+      Position: [0, 0, -20]
+      Rotation: [0, 10, 0]
+      Scale: [0.0500000007, 0.0500000007, 0.0500000007]

--- a/Edge/src/EdgeApp.cpp
+++ b/Edge/src/EdgeApp.cpp
@@ -19,10 +19,22 @@ public:
 	* Processes input from the user for the editor as well as calls Engine::ProcessInput()
 	*/
 	void ProcessInput();
-	void RenderSceneViewport(Razor::Ref<Razor::Framebuffer> SceneBuffer, ImVec2& ViewportSize);
+	void RenderSceneViewport(Razor::Ref<Razor::Framebuffer> SceneBuffer);
+	/**
+	* Function to pick and object via the PickBuffer
+	* Needs it's functionality properly implemented
+	*
+	* @param PickBuffer - Shared Ptr to the FrameBuffer used as the PickBuffer
+	* @param Offset - 2D vector to offset mouse position based on viewport position
+	*/
+	void PickObject(ImVec2 Offset);
 
 private:
 	EdgeEditor::EditorCamera EditorCamera; /** Object to house and control the camera we will use for rendering the scene to the viewport */
+	Razor::Ref<Razor::Framebuffer> PickBuffer; /** Framebuffer object for picking objects */
+	Razor::Ref<Razor::Framebuffer> SceneBuffer; /** Framebuffer object for rendering scene */
+	ImVec2 ViewportSize; /** 2D vector to hold size of viewport window */
+	ImVec2 ViewportPos; /** 2D vector to hold position of image displaying scene texture for viewport*/
 };
 
 Razor::Application* Razor::CreateApplication()
@@ -32,10 +44,6 @@ Razor::Application* Razor::CreateApplication()
 
 void Edge::Run()
 {
-	ImVec2 ViewportSize;
-	Razor::Ref<Razor::Framebuffer> PickBuffer;
-	Razor::Ref<Razor::Framebuffer> SceneBuffer;
-
 	Razor::Engine& Engine = Razor::Engine::Get();
 
 	Razor::RenderPipelineConfig PipelineConfig;
@@ -64,9 +72,8 @@ void Edge::Run()
 
 	Razor::RenderPipelineConfig PickPipelineConfig;
 	PickPipelineConfig.push_back(Razor::RenderStageConfig{ Razor::RenderStage::RENDER_STAGE_MATERIAL_PASS, std::vector<const char*> { typeid(Razor::RSPickBufferMaterialPass).name() } });
-	PickPipelineConfig.push_back(Razor::RenderStageConfig{ Razor::RenderStage::RENDER_STAGE_LIGHTING_PASS, std::vector<const char*> { typeid(Razor::RSDirectionalLightingPass).name() } });
 	PickPipelineConfig.push_back(Razor::RenderStageConfig{ Razor::RenderStage::RENDER_STAGE_TRANSFORMATION_PASS, std::vector<const char*> { typeid(Razor::RSTransformationsPass).name() } });
-	PickPipelineConfig.push_back(Razor::RenderStageConfig{ Razor::RenderStage::RENDER_STAGE_CAMERA_PASS, std::vector<const char*> { typeid(Razor::RSCameraPass).name() } });
+	PickPipelineConfig.push_back(Razor::RenderStageConfig{ Razor::RenderStage::RENDER_STAGE_CAMERA_PASS, std::vector<const char*> { typeid(EdgeEditor::RSEditorCamera).name() } });
 	PickPipelineConfig.push_back(Razor::RenderStageConfig{ Razor::RenderStage::RENDER_STAGE_RENDER, std::vector<const char*> { typeid(Razor::RSPickBufferRenderPass).name() } });
 
 	Engine.GetCoordinator()->RegisterSystem<EdgeEditor::RSEditorCamera>(EdgeEditor::RSEditorCamera(Engine.CurrentScene, Engine.GetRenderer(), EditorCamera.GetCamera()));
@@ -98,16 +105,13 @@ void Edge::Run()
 		SceneBuffer->Refresh(SizeX, SizeY);
 		glViewport(0, 0, SizeX, SizeY);
 
-		ProcessInput();
-
-		Engine.RunSystems();
-
 		std::shared_ptr<Razor::IRenderer>& Renderer = Engine.Renderer;
 
 		Renderer->BindFrameBuffer(PickBuffer->GetID());
 		Renderer->ClearBuffer();
 		Engine.RunRenderSystems(PickPipelineConfig);
-		Engine.PickObject(PickBuffer->GetID());
+
+		ProcessInput();
 
 		Renderer->BindFrameBuffer(SceneBuffer->GetID());
 		Renderer->ClearBuffer();
@@ -117,12 +121,15 @@ void Edge::Run()
 		Renderer->ClearBuffer();
 
 		Renderer->PollForEvents();
+
+		Engine.RunSystems();
+
 		Engine.GetGUI().BeginNewFrame();
 		Engine.GetGUI().CreateDockspace();
 		InspectorWindow.Render();
 		SceneViewWindow.Render();
 		ProjectExplorerWindow.Render();
-		RenderSceneViewport(SceneBuffer, ViewportSize);
+		RenderSceneViewport(PickBuffer);
 		ImGui::ShowMetricsWindow();
 		ImGui::End();
 		Engine.GetGUI().EndFrame(Razor::Engine::Get().GetWindow(), Razor::Engine::Get().Renderer);
@@ -132,12 +139,13 @@ void Edge::Run()
 	Razor::Engine::Get().Renderer->TerminateRendererAPI();
 }
 
-void Edge::RenderSceneViewport(Razor::Ref<Razor::Framebuffer> SceneBuffer, ImVec2& ViewportSize)
+void Edge::RenderSceneViewport(Razor::Ref<Razor::Framebuffer> SceneBuffer)
 {
 	bool bIsOpen;
 	ImGui::Begin("Scene", &bIsOpen, ImGuiWindowFlags_MenuBar || ImGuiWindowFlags_NoScrollbar);
 	ViewportSize = ImVec2(ImGui::GetContentRegionAvail().x, ImGui::GetContentRegionAvail().y);
 	ImGui::Image(reinterpret_cast<void*>(SceneBuffer->GetTexture()), ImVec2(ViewportSize.x, ViewportSize.y), ImVec2(0, 1), ImVec2(1, 0));
+	ViewportPos = ImGui::GetItemRectMin();
 	ImGui::End();
 }
 
@@ -146,4 +154,29 @@ void Edge::ProcessInput()
 	Razor::Engine::Get().ProcessInput();
 
 	EditorCamera.ProcessInput(Razor::Engine::Get().GetDeltaTime());
+
+	if (RazorIO::Get().GetStateForMouseButton(LEFT) == MOUSE_DOWN)
+	{
+		Vector2D MousePos = RazorIO::Get().CurrentMousePos;
+		unsigned int OffsetMousePosX = MousePos.X - ViewportPos.x;
+		unsigned int OffsetMousePosY = MousePos.Y - ViewportPos.y;
+
+		if (OffsetMousePosX < 0 || OffsetMousePosX > PickBuffer->GetWidth() || OffsetMousePosY < 0 || OffsetMousePosY > PickBuffer->GetHeight())
+		{
+			return;
+		}
+		PickObject(ImVec2(OffsetMousePosX, OffsetMousePosY));
+	}
+}
+
+void Edge::PickObject(ImVec2 MousePos)
+{
+	float Pixel[3];
+	Razor::Engine::Get().GetRenderer()->ReadPixels(MousePos.x, PickBuffer->GetHeight() - MousePos.y, 1, 1, Pixel, PickBuffer->GetID());
+	std::uint32_t PickedEntity = 0;
+	PickedEntity = static_cast<std::uint32_t>(Pixel[0] * 255.0f) + (std::uint32_t(Pixel[1] * 255.0f) << 8)
+			+ (std::uint32_t(Pixel[2] * 255.0f) << 16);
+	RZ_INFO("Mouse Pos x:{0} y:{1}", MousePos.x, MousePos.y);
+	RZ_INFO("Picked color {0}, {1}, {2}", Pixel[0], Pixel[1], Pixel[2]);
+	RZ_INFO("Picked entity {0}", PickedEntity);
 }

--- a/Edge/src/EdgeApp.cpp
+++ b/Edge/src/EdgeApp.cpp
@@ -35,6 +35,7 @@ private:
 	Razor::Ref<Razor::Framebuffer> SceneBuffer; /** Framebuffer object for rendering scene */
 	ImVec2 ViewportSize; /** 2D vector to hold size of viewport window */
 	ImVec2 ViewportPos; /** 2D vector to hold position of image displaying scene texture for viewport*/
+	Razor::Ref<EdgeEditor::EditorStorage> Storage; /** Container object to hold data to be shared among windows*/
 };
 
 Razor::Application* Razor::CreateApplication()
@@ -86,7 +87,7 @@ void Edge::Run()
 	Razor::Model DefaultModel = Engine.ProcessModel("resources/models/Cube.obj");
 	DefaultModel.SetModelShader(Engine.GetShaderForType(typeid(Razor::DefaultMeshShader).name())->ID);
 
-	Razor::Ref<EdgeEditor::EditorStorage> Storage = std::make_shared<EdgeEditor::EditorStorage>();
+	Storage = std::make_shared<EdgeEditor::EditorStorage>();
 	Storage->DefaultModel = DefaultModel;
 
 	EdgeEditor::Inspector InspectorWindow(Storage);
@@ -179,4 +180,5 @@ void Edge::PickObject(ImVec2 MousePos)
 	RZ_INFO("Mouse Pos x:{0} y:{1}", MousePos.x, MousePos.y);
 	RZ_INFO("Picked color {0}, {1}, {2}", Pixel[0], Pixel[1], Pixel[2]);
 	RZ_INFO("Picked entity {0}", PickedEntity);
+	Storage->SelectedEntity = Razor::Engine::Get().CurrentScene->GetEntity(entt::entity(PickedEntity));
 }

--- a/Edge/src/EditorCamera.cpp
+++ b/Edge/src/EditorCamera.cpp
@@ -40,8 +40,6 @@ namespace EdgeEditor
 
 			if (MouseLastX != CurrentMouseCoords.X || MouseLastY != CurrentMouseCoords.Y)
 			{
-				RZ_CORE_INFO("MouseCoords: {0},{1}", CurrentMouseCoords.X, CurrentMouseCoords.Y);
-				RZ_CORE_INFO("LastMouseCoords: {0},{1}", MouseLastX, MouseLastY);
 				float Xoffset = RazorIO::Get().CurrentMousePos.X - MouseLastX;
 				float Yoffset = RazorIO::Get().CurrentMousePos.Y - MouseLastY;
 

--- a/Razor/src/Platform/OpenGL/OpenGLWindowProvider.cpp
+++ b/Razor/src/Platform/OpenGL/OpenGLWindowProvider.cpp
@@ -1,5 +1,6 @@
 #include "OpenGLWindowProvider.h"
 #include <iostream>
+#include "../../Razor/Engine.h"
 
 
 namespace Razor
@@ -7,6 +8,8 @@ namespace Razor
     void framebuffer_size_callback(GLFWwindow* window, int width, int height)
     {
         glViewport(0, 0, width, height);
+        Engine::Get().GetWindow().SetWidth(width);
+        Engine::Get().GetWindow().SetHeight(height);
         // Think what we want is to re-create our framebuffers to be of this width and height rather than try resizing them
         ///Renderer->ResizeFramebuffers(width, height);
     }

--- a/Razor/src/Razor/Engine.cpp
+++ b/Razor/src/Razor/Engine.cpp
@@ -110,19 +110,6 @@ namespace Razor
 		}
 	}
 
-	void Engine::PickObject(unsigned int PickBuffer)
-	{
-		if (RazorIO::Get().GetStateForMouseButton(LEFT) == MOUSE_DOWN)
-		{
-			Vector2D MousePos = RazorIO::Get().CurrentMousePos;
-			unsigned char Pixel[4];
-			Renderer->ReadPixels(MousePos.X, 600 - MousePos.Y, 1, 1, Pixel, PickBuffer);
-			int PickedEntity = 0;
-			PickedEntity = static_cast<int>(Pixel[0]) << 16 | static_cast<int>(Pixel[1]) << 8 | static_cast<int>(Pixel[2]);
-			//RZ_CORE_INFO("Picked {0}", PickedEntity);
-		}
-	}
-
 	void Engine::RenderImGui(uint64_t SceneTexture)
 	{
 		

--- a/Razor/src/Razor/Engine.h
+++ b/Razor/src/Razor/Engine.h
@@ -127,13 +127,6 @@ namespace Razor
 		* This just checks for the close event on the window
 		*/
 		void ProcessInput();
-		/**
-		* Function to pick and object via the PickBuffer
-		* Needs it's functionality properly implemented
-		* 
-		* @param PickBuffer - An unsigned int pointing to the FrameBuffer used as the PickBuffer
-		*/
-		void PickObject(unsigned int PickBuffer);
 		// TODO move this
 		/**
 		* Function to process Model from .obj file to Model object

--- a/Razor/src/Razor/Renderer/IRenderer.h
+++ b/Razor/src/Razor/Renderer/IRenderer.h
@@ -41,7 +41,17 @@ namespace Razor
 		virtual void BindFrameBuffer(uint32_t = 0) = 0;
 		virtual Ref<Framebuffer> CreateFrameBuffer(uint32_t Width, uint32_t Height) = 0;
 		virtual CameraInfo GetCameraInfo() = 0;
-		virtual void ReadPixels(unsigned int X, unsigned int Y, unsigned int Width, unsigned int Height, unsigned char* OutPixels, unsigned int Buffer) = 0;
+		/**
+		* Function to read pixels from a frame buffer out to a float ptr
+		* 
+		* @param X - the x-coord we are looking for in the buffer
+		* @param Y - the y-coord we are looking for in the buffer
+		* @param Width - the width of pixels we are reading 
+		* @param Height - the height of pixels we are reading
+		* @param OutPixels - the pixels resulting from the read
+		* @param Buffer - int corresponding to buffer we are reading from
+		*/
+		virtual void ReadPixels(unsigned int X, unsigned int Y, unsigned int Width, unsigned int Height, float* OutPixels, unsigned int Buffer) = 0;
 		virtual void BackupContext() = 0;
 		virtual void ResetCurrentContext() = 0;
 		virtual void* GetSceneRenderedToTexture() = 0;

--- a/Razor/src/Razor/Renderer/OpenGL/GLFramebuffer.h
+++ b/Razor/src/Razor/Renderer/OpenGL/GLFramebuffer.h
@@ -34,7 +34,6 @@ namespace Razor
         {
             if ((InWidth != Width || InHeight != Height) && (InHeight != 0 && InWidth != 0))
             {
-                RZ_CORE_WARN("Invalidating current framebuffer old({0},{1}) vs new({2},{3})", Width, Height, InWidth, InHeight);
                 Width = InWidth;
                 Height = InHeight;
                 Invalidate();

--- a/Razor/src/Razor/Renderer/OpenGLRenderer.cpp
+++ b/Razor/src/Razor/Renderer/OpenGLRenderer.cpp
@@ -124,10 +124,10 @@ namespace Razor
         glfwSwapBuffers(std::dynamic_pointer_cast<OpenGLWindowProvider>(window.GetWindowProvider())->GetPlatformWindowPtr());
     }
 
-    void OpenGLRenderer::ReadPixels(unsigned int X, unsigned int Y, unsigned int Width, unsigned int Height, unsigned char* OutPixels, unsigned int Buffer)
+    void OpenGLRenderer::ReadPixels(unsigned int X, unsigned int Y, unsigned int Width, unsigned int Height, float* OutPixels, unsigned int Buffer)
     {
         glReadBuffer(GL_COLOR_ATTACHMENT0);
-        glReadPixels(X, Y, Width, Height, GL_RGBA, GL_UNSIGNED_BYTE, OutPixels);
+        glReadPixels(X, Y, Width, Height, GL_RGB, GL_FLOAT, OutPixels);
     }
 
     void OpenGLRenderer::BackupContext()

--- a/Razor/src/Razor/Renderer/OpenGLRenderer.h
+++ b/Razor/src/Razor/Renderer/OpenGLRenderer.h
@@ -22,7 +22,7 @@ namespace Razor
 		void ClearBuffer() override;
 		void BindFrameBuffer(uint32_t BufferIndex = 0) override;
 		Ref<Framebuffer> CreateFrameBuffer(uint32_t Width, uint32_t Height) override;
-		void ReadPixels(unsigned int X, unsigned int Y, unsigned int I1, unsigned int I2, unsigned char* OutPixels, unsigned int Buffer) override;
+		void ReadPixels(unsigned int X, unsigned int Y, unsigned int I1, unsigned int I2, float* OutPixels, unsigned int Buffer) override;
 		void SwapBuffer(Window& window) override;
 		void BackupContext() override;
 		void ResetCurrentContext() override;

--- a/Razor/src/Razor/Scene/Scene.cpp
+++ b/Razor/src/Razor/Scene/Scene.cpp
@@ -1,5 +1,6 @@
 #include "Scene.h"
 #include "../Core/Entity.h"
+#include "../Component.h"
 
 namespace Razor
 {
@@ -21,7 +22,9 @@ namespace Razor
 	
 	Ref<Entity> Scene::GetEntity(entt::entity EntityHandle)
 	{
-		return CreateRef<Entity>(EntityHandle, this);
+		Ref<Entity> Entt = CreateRef<Entity>(EntityHandle, this);
+		
+		return Entt->HasComponent<Transform>() ? Entt : nullptr;
 	}
 	
 }

--- a/Razor/src/Razor/Systems/RSPickBufferMaterialPass.cpp
+++ b/Razor/src/Razor/Systems/RSPickBufferMaterialPass.cpp
@@ -21,9 +21,10 @@ namespace Razor
 			{
 				PropertySlot& Slot = Property.GetPropertySlot(i);
 				//Red, Green, Blue
-				glm::vec3 EntityColor = glm::vec3(((1 >> 16) & 0xff) / 255.0f,
-					((1 >> 8) & 0xff) / 255.0f, 
-					(1 & 0xff) / 255.0f);
+				std::uint32_t Id = (std::uint32_t)RenderingEntity;
+				glm::vec3 EntityColor = glm::vec3((Id & 0x000000FF) / 255.0f,
+					((Id & 0x0000FF00) >> 8) / 255.0f,
+					((Id & 0x00FF0000) >> 16) / 255.0f);
 				Slot.AddProperty<glm::vec3>("entitycolor", EntityColor);
 			}
 		}

--- a/Razor/src/Razor/Window.cpp
+++ b/Razor/src/Razor/Window.cpp
@@ -34,4 +34,14 @@ namespace Razor
     {
         return Height;
     }
+
+    void Window::SetWidth(int Value)
+    {
+        Width = Value;
+    }
+
+    void Window::SetHeight(int Value)
+    {
+        Height = Value;
+    }
 }

--- a/Razor/src/Razor/Window.h
+++ b/Razor/src/Razor/Window.h
@@ -16,6 +16,18 @@ namespace Razor
         void SetWindowToClose();
         int GetWidth() const;
         int GetHeight() const;
+        /**
+        * Setter function for window width
+        * 
+        * @param Value - the value to set Window Width to
+        */
+        void SetWidth(int Value);
+        /**
+        * Setter function for window height
+        *
+        * @param Value - the value to set Window Height to
+        */
+        void SetHeight(int Value);
 
     protected:
         std::shared_ptr<IWindowProvider> Provider;


### PR DESCRIPTION
Users can now select objects from directly in the viewport rather than having to select from the Scene View instead.

As well as deselect by clicking off the object into empty space.