### PR TITLE
Feat - Sandbox Implement Editor Creates Project

### DIFF
--- a/Edge/Untitled.rzscn
+++ b/Edge/Untitled.rzscn
@@ -2,9 +2,9 @@ Scene: Untitled
 Entities:
   - Entity: 5
     Transform:
-      Position: [10, 0, -20]
-      Rotation: [0, 0, 0]
-      Scale: [0, 0, 0]
+      Position: [0, 0, -20]
+      Rotation: [0, 10, 0]
+      Scale: [0.0500000007, 0.0500000007, 0.0500000007]
   - Entity: 4
     Transform:
       Position: [0, 0, 0]
@@ -27,6 +27,6 @@ Entities:
       Scale: [0, 0, 0]
   - Entity: 0
     Transform:
-      Position: [0, 0, -20]
-      Rotation: [0, 10, 0]
-      Scale: [0.0500000007, 0.0500000007, 0.0500000007]
+      Position: [10, 0, -20]
+      Rotation: [0, 0, 0]
+      Scale: [0, 0, 0]

--- a/Edge/Untitled.rzscn
+++ b/Edge/Untitled.rzscn
@@ -2,9 +2,9 @@ Scene: Untitled
 Entities:
   - Entity: 5
     Transform:
-      Position: [0, 0, -20]
-      Rotation: [0, 10, 0]
-      Scale: [0.0500000007, 0.0500000007, 0.0500000007]
+      Position: [10, 0, -20]
+      Rotation: [0, 0, 0]
+      Scale: [0, 0, 0]
   - Entity: 4
     Transform:
       Position: [0, 0, 0]
@@ -27,6 +27,6 @@ Entities:
       Scale: [0, 0, 0]
   - Entity: 0
     Transform:
-      Position: [10, 0, -20]
-      Rotation: [0, 0, 0]
-      Scale: [0, 0, 0]
+      Position: [0, 0, -20]
+      Rotation: [0, 10, 0]
+      Scale: [0.0500000007, 0.0500000007, 0.0500000007]

--- a/Edge/src/EdgeApp.cpp
+++ b/Edge/src/EdgeApp.cpp
@@ -3,7 +3,7 @@
 
 #include "Inspector.h"
 #include "SceneView.h"
-#include "../EditorStorage.h"
+#include "EditorStorage.h"
 #include "ProjectExplorer.h"
 #include "Systems/RSEditorCamera.h"
 #include "EditorCamera.h"
@@ -126,7 +126,7 @@ void Edge::Run()
 		Engine.RunSystems();
 
 		Engine.GetGUI().BeginNewFrame();
-		Engine.GetGUI().CreateDockspace();
+		Engine.GetGUI().CreateDockspace("Edge");
 		InspectorWindow.Render();
 		SceneViewWindow.Render();
 		ProjectExplorerWindow.Render();

--- a/Edge/src/EdgeApp.cpp
+++ b/Edge/src/EdgeApp.cpp
@@ -7,6 +7,10 @@
 #include "ProjectExplorer.h"
 #include "Systems/RSEditorCamera.h"
 #include "EditorCamera.h"
+#include "FileIO/ProjectSerializer.h"
+#include "misc/cpp/imgui_stdlib.h"
+#include "Gui/NewProjectPopupWindow.h"
+
 
 
 class Edge : public Razor::Application
@@ -28,6 +32,15 @@ public:
 	* @param Offset - 2D vector to offset mouse position based on viewport position
 	*/
 	void PickObject(ImVec2 Offset);
+	/**
+	* Function to create an ImGui dockspace
+	* 
+	* @param Title - string to use as title
+	*/
+	void CreateDockspace(const std::string& Title);
+
+private:
+	EdgeEditor::PopupWindow* CurrentPopup = nullptr; /** Holds current popup open */
 
 private:
 	EdgeEditor::EditorCamera EditorCamera; /** Object to house and control the camera we will use for rendering the scene to the viewport */
@@ -126,13 +139,21 @@ void Edge::Run()
 		Engine.RunSystems();
 
 		Engine.GetGUI().BeginNewFrame();
-		Engine.GetGUI().CreateDockspace("Edge");
+		CreateDockspace("Edge");
 		InspectorWindow.Render();
 		SceneViewWindow.Render();
 		ProjectExplorerWindow.Render();
 		RenderSceneViewport(SceneBuffer);
 		ImGui::ShowMetricsWindow();
 		ImGui::End();
+		if (CurrentPopup)
+		{
+			if (CurrentPopup->Draw() == false)
+			{
+				delete(CurrentPopup);
+				CurrentPopup = nullptr;
+			}
+		}
 		Engine.GetGUI().EndFrame(Razor::Engine::Get().GetWindow(), Razor::Engine::Get().Renderer);
 		Engine.Renderer->SwapBuffer(Razor::Engine::Get().GetWindow());
 	}
@@ -178,4 +199,31 @@ void Edge::PickObject(ImVec2 MousePos)
 	PickedEntity = static_cast<std::uint32_t>(Pixel[0] * 255.0f) + (std::uint32_t(Pixel[1] * 255.0f) << 8)
 			+ (std::uint32_t(Pixel[2] * 255.0f) << 16);
 	Storage->SelectedEntity = Razor::Engine::Get().CurrentScene->GetEntity(entt::entity(PickedEntity));
+}
+
+void Edge::CreateDockspace(const std::string& Title)
+{
+	bool bIsOpen;
+	bool bIsDockspaceOpen;
+	ImGuiWindowFlags window_flags = ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoDocking;
+	ImGuiViewport* viewport = ImGui::GetMainViewport();
+	ImGui::SetNextWindowPos(viewport->Pos);
+	ImGui::SetNextWindowSize(viewport->Size);
+	ImGui::SetNextWindowViewport(viewport->ID);
+	window_flags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove;
+	window_flags |= ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus;
+	ImGui::Begin(Title.c_str(), &bIsDockspaceOpen, window_flags);
+	if (ImGui::BeginMainMenuBar())
+	{
+		if (ImGui::BeginMenu("File"))
+		{
+			if (ImGui::MenuItem("Create Project"))
+			{
+				CurrentPopup = new EdgeEditor::NewProjectPopupWindow();
+			}
+			ImGui::EndMenu();
+		}
+		ImGui::EndMainMenuBar();
+	}
+	ImGui::DockSpace(ImGui::GetID(Title.c_str()), ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_None);
 }

--- a/Edge/src/EditorStorage.h
+++ b/Edge/src/EditorStorage.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Razor.h>
+#include "Project.h"
 
 namespace EdgeEditor
 {
@@ -9,6 +10,7 @@ namespace EdgeEditor
 		EditorStorage() : SelectedEntity(nullptr) {}
 		Razor::Ref<Razor::Entity> SelectedEntity;
 		Razor::Model DefaultModel;
+		Project CurrentProject;
 	};
 }
 

--- a/Edge/src/FileIO/ProjectSerializer.cpp
+++ b/Edge/src/FileIO/ProjectSerializer.cpp
@@ -2,6 +2,7 @@
 #include "../Project.h"
 #include <yaml-cpp/yaml.h>
 #include <fstream>
+#include <filesystem>
 
 
 namespace EdgeEditor
@@ -9,6 +10,24 @@ namespace EdgeEditor
 
 	void ProjectSerializer::Serialize(const std::string& Path, Razor::Ref<Project> Project)
 	{
+		if (Project == nullptr)
+		{
+			RZ_ERROR("ProjectSerializer::Serialize Error: Project Ptr passed in was null");
+			return;
+		}
+
+		if (Project->ProjectName == "")
+		{
+			RZ_ERROR("ProjectSerializer::Serialize Error: Project Name cannot be an empty string");
+			return;
+		}
+
+		const std::string ProjectFolderPath = Path + "/" + Project->ProjectName;
+		const std::string AssetFolderPath = ProjectFolderPath + "/" + "assets";
+		const std::string DllFolderPath = ProjectFolderPath + "/" + "assembly";
+
+		Project->AssetDirectory = AssetFolderPath;
+		Project->DllDirectory = DllFolderPath;
 
 		YAML::Emitter Out;
 		Out << YAML::BeginMap;
@@ -18,7 +37,11 @@ namespace EdgeEditor
 		Out << YAML::Key << "MainScenePath" << YAML::Value << Project->MainScenePath;
 		Out << YAML::EndMap;
 
-		const std::string PathPlusExt = Path + ".proj";
+		std::filesystem::create_directory(ProjectFolderPath);
+		std::filesystem::create_directory(AssetFolderPath);
+		std::filesystem::create_directory(DllFolderPath);
+
+		const std::string PathPlusExt = ProjectFolderPath + "/" + Project->ProjectName + ".proj";
 
 		std::ofstream FOut(PathPlusExt.c_str());
 		const char* ErrorMsg = new char(' ');

--- a/Edge/src/FileIO/ProjectSerializer.cpp
+++ b/Edge/src/FileIO/ProjectSerializer.cpp
@@ -1,0 +1,58 @@
+#include "ProjectSerializer.h"
+#include "../Project.h"
+#include <yaml-cpp/yaml.h>
+#include <fstream>
+
+
+namespace EdgeEditor
+{
+
+	void ProjectSerializer::Serialize(const std::string& Path, Razor::Ref<Project> Project)
+	{
+
+		YAML::Emitter Out;
+		Out << YAML::BeginMap;
+		Out << YAML::Key << "ProjectName" << YAML::Value << Project->ProjectName;
+		Out << YAML::Key << "AssetDirectory" << YAML::Value << Project->AssetDirectory;
+		Out << YAML::Key << "DllDirectory" << YAML::Value << Project->DllDirectory;
+		Out << YAML::Key << "MainScenePath" << YAML::Value << Project->MainScenePath;
+		Out << YAML::EndMap;
+
+		const std::string PathPlusExt = Path + ".proj";
+
+		std::ofstream FOut(PathPlusExt.c_str());
+		const char* ErrorMsg = new char(' ');
+		std::perror(ErrorMsg);
+		RZ_WARN("Error Msg: {0}", ErrorMsg);
+		FOut << Out.c_str();
+		FOut.close();
+	}
+
+	void ProjectSerializer::Deserialize(const std::string& Path, Razor::Ref<Project> OutProject)
+	{
+
+		YAML::Node Data;
+		const std::string PathPlusExt = Path + ".proj";
+		try
+		{
+			Data = YAML::LoadFile(PathPlusExt);
+		}
+		catch (YAML::ParserException e)
+		{
+			RZ_ERROR("Failed to load .proj file '{0}'\n	{1}", PathPlusExt, e.what());
+			return;
+		}
+
+		if (!Data["ProjectName"])
+		{
+			RZ_ERROR("Incomplete .proj file missing 'ProjectName' key");
+			return;
+		}
+		
+		OutProject->ProjectName = Data["ProjectName"].as<std::string>();
+		OutProject->AssetDirectory = Data["AssetDirectory"].as<std::string>();
+		OutProject->DllDirectory = Data["DllDirectory"].as<std::string>();
+		OutProject->MainScenePath = Data["MainScenePath"].as<std::string>();
+	}
+
+}

--- a/Edge/src/FileIO/ProjectSerializer.h
+++ b/Edge/src/FileIO/ProjectSerializer.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Razor.h"
+
+namespace EdgeEditor
+{
+	struct Project;
+
+	class ProjectSerializer
+	{
+	public:
+		/**
+		* Serialize a Project object and save to the provided path in YAML format
+		*
+		* @param Path The path which we will save the YAML file to
+		* @param Project The project object to be serialized
+		*/
+		static void Serialize(const std::string& Path, Razor::Ref<Project> Project);
+		/**
+		* Deserialize a Project object from the provided path
+		*
+		* @param Path The path which we will load the YAML file from
+		* @param OutProject The project object to be created from the data in the file
+		*/
+		static void Deserialize(const std::string& Path, Razor::Ref<Project> OutProject);
+	};
+}
+

--- a/Edge/src/Gui/NewProjectPopupWindow.cpp
+++ b/Edge/src/Gui/NewProjectPopupWindow.cpp
@@ -1,0 +1,44 @@
+#include "NewProjectPopupWindow.h"
+#include "../FileIO/ProjectSerializer.h"
+//TODO move to Razor.h
+#include "misc/cpp/imgui_stdlib.h"
+
+namespace EdgeEditor
+{
+	bool NewProjectPopupWindow::Draw()
+	{
+		const std::string MagicalPathToFixWithActualSelectedPathSoon = "../../Sandboxes/";
+
+		bool bIsOpen = true;
+		if (NewProject == nullptr)
+		{
+			Open();
+		}
+		if (ImGui::BeginPopupModal("New Project Window", nullptr))
+		{
+			ImGui::InputText("Project Name", &NewProject->ProjectName);
+			if (ImGui::Button("Create"))
+			{
+				EdgeEditor::ProjectSerializer::Serialize(MagicalPathToFixWithActualSelectedPathSoon, NewProject);
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("Cancel"))
+			{ 
+				Close();
+				bIsOpen = false;
+			}
+			ImGui::EndPopup();
+		}
+		return bIsOpen;
+	}
+	void NewProjectPopupWindow::Open()
+	{
+		NewProject = Razor::CreateRef<Project>();
+		ImGui::OpenPopup("New Project Window");
+	}
+	void NewProjectPopupWindow::Close()
+	{
+		ImGui::CloseCurrentPopup();
+	}
+}

--- a/Edge/src/Gui/NewProjectPopupWindow.h
+++ b/Edge/src/Gui/NewProjectPopupWindow.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <Razor.h>
+#include "../Project.h"
+#include "PopupWindow.h"
+
+namespace EdgeEditor
+{
+	/**
+	* Class for popup window to create new project inherits from base PopupWindow class
+	*/
+	class NewProjectPopupWindow : public PopupWindow
+	{
+	public:
+		/**
+		* Function to draw popup window function to be called when wishing to draw popup
+		*/
+		bool Draw() override;
+
+	private:
+		/**
+		* Function to handle opening logic for popup such as ImGui calls and initialising NewProject
+		*/
+		void Open() override;
+		/**
+		* Function to handle closing logic for popup such as ImGui calls
+		*/
+		void Close() override;
+
+		Razor::Ref<Project> NewProject; /** New Project to potentially be created */
+	};
+}
+

--- a/Edge/src/Gui/PopupWindow.cpp
+++ b/Edge/src/Gui/PopupWindow.cpp
@@ -1,0 +1,1 @@
+#include "PopupWindow.h"

--- a/Edge/src/Gui/PopupWindow.h
+++ b/Edge/src/Gui/PopupWindow.h
@@ -1,0 +1,29 @@
+#pragma once
+
+namespace EdgeEditor
+{
+	/**
+	* Base class for popup windows
+	*/
+	class PopupWindow
+	{
+	public:
+		/**
+		* Function to draw popup window function to be called when wishing to draw popup
+		*/
+		virtual bool Draw() = 0;
+
+	private:
+		/**
+		* Function to handle opening logic for popup such as ImGui calls
+		*/
+		virtual void Open() = 0;
+		/**
+		* Function to handle closing logic for popup such as ImGui calls
+		*/
+		virtual void Close() = 0;
+
+	};
+
+}
+

--- a/Edge/src/Inspector.h
+++ b/Edge/src/Inspector.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Razor.h"
-#include "../EditorStorage.h"
+#include "EditorStorage.h"
 
 
 namespace EdgeEditor

--- a/Edge/src/Project.h
+++ b/Edge/src/Project.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <string>
+
+namespace EdgeEditor
+{
+	/**
+	* Struct to hold data about this game project
+	*/
+	struct Project
+	{
+		std::string ProjectName; /** Name of the project */
+		std::string AssetDirectory; /** Directory containing all the asset files */
+		std::string DllDirectory; /** Directory containing the scripting DLL */
+		std::string MainScenePath; /** Path to the main scene (we will open this on load up)*/
+
+		/**
+		* Default constructor for Project class
+		*/
+		Project() : ProjectName(""), AssetDirectory(""), DllDirectory("")
+		{
+
+		}
+
+		/**
+		* Constructor for Project class
+		* 
+		* @param ProjectName - name for the project
+		* @param AssetDirectory - directory containing all the asset files
+		* @param DllDirectory - directory containing the scripting DLL
+		*/
+		Project(std::string ProjectName, std::string AssetDirectory, std::string DllDirectory)
+			: ProjectName(ProjectName), AssetDirectory(AssetDirectory), DllDirectory(DllDirectory)
+		{
+
+		}
+	};
+}

--- a/Edge/src/ProjectExplorer.h
+++ b/Edge/src/ProjectExplorer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Razor.h"
-#include "../EditorStorage.h"
+#include "EditorStorage.h"
 
 namespace EdgeEditor
 {

--- a/Edge/src/SceneView.h
+++ b/Edge/src/SceneView.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Razor.h>
-#include "../EditorStorage.h"
+#include "EditorStorage.h"
 
 namespace EdgeEditor
 {

--- a/Razor/src/Razor/ImGui/RazorImGui.cpp
+++ b/Razor/src/Razor/ImGui/RazorImGui.cpp
@@ -62,21 +62,6 @@ namespace Razor
 		//RZ_CORE_INFO("Mouse Pos: {0},{1}", ImGui::GetIO().MousePos.x, ImGui::GetIO().MousePos.y);
 	}
 
-	void RazorImGui::CreateDockspace(const std::string& Title)
-	{
-		bool bIsOpen;
-		bool bIsDockspaceOpen;
-		ImGuiWindowFlags window_flags = ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoDocking;
-		ImGuiViewport* viewport = ImGui::GetMainViewport();
-		ImGui::SetNextWindowPos(viewport->Pos);
-		ImGui::SetNextWindowSize(viewport->Size);
-		ImGui::SetNextWindowViewport(viewport->ID);
-		window_flags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove;
-		window_flags |= ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus;
-		ImGui::Begin(Title.c_str(), &bIsDockspaceOpen, window_flags);
-		ImGui::DockSpace(ImGui::GetID(Title.c_str()), ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_None);
-	}
-
 	void RazorImGui::RegisterImGuiEvents()
 	{
 		RazorIO& EngineIO = RazorIO::Get();

--- a/Razor/src/Razor/ImGui/RazorImGui.cpp
+++ b/Razor/src/Razor/ImGui/RazorImGui.cpp
@@ -62,7 +62,7 @@ namespace Razor
 		//RZ_CORE_INFO("Mouse Pos: {0},{1}", ImGui::GetIO().MousePos.x, ImGui::GetIO().MousePos.y);
 	}
 
-	void RazorImGui::CreateDockspace()
+	void RazorImGui::CreateDockspace(const std::string& Title)
 	{
 		bool bIsOpen;
 		bool bIsDockspaceOpen;
@@ -73,8 +73,8 @@ namespace Razor
 		ImGui::SetNextWindowViewport(viewport->ID);
 		window_flags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove;
 		window_flags |= ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus;
-		ImGui::Begin("Dockspace", &bIsDockspaceOpen, window_flags);
-		ImGui::DockSpace(ImGui::GetID("Dockspace"), ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_None);
+		ImGui::Begin(Title.c_str(), &bIsDockspaceOpen, window_flags);
+		ImGui::DockSpace(ImGui::GetID(Title.c_str()), ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_None);
 	}
 
 	void RazorImGui::RegisterImGuiEvents()

--- a/Razor/src/Razor/ImGui/RazorImGui.h
+++ b/Razor/src/Razor/ImGui/RazorImGui.h
@@ -14,7 +14,7 @@ namespace Razor
 		void Setup(const std::shared_ptr<IWindowProvider>& WindowProvider);
 		void BeginNewFrame();
 		void EndFrame(const Window& RenderWindow, Ref<IRenderer> Renderer);
-		void CreateDockspace();
+		void CreateDockspace(const std::string& Title = "New Dockspace");
 	public:
 		// Function to hook our on such and such events to GLFW key events
 		void RegisterImGuiEvents();

--- a/Razor/src/Razor/ImGui/RazorImGui.h
+++ b/Razor/src/Razor/ImGui/RazorImGui.h
@@ -14,7 +14,6 @@ namespace Razor
 		void Setup(const std::shared_ptr<IWindowProvider>& WindowProvider);
 		void BeginNewFrame();
 		void EndFrame(const Window& RenderWindow, Ref<IRenderer> Renderer);
-		void CreateDockspace(const std::string& Title = "New Dockspace");
 	public:
 		// Function to hook our on such and such events to GLFW key events
 		void RegisterImGuiEvents();


### PR DESCRIPTION
## Add - Project Type

Problem:
Require a object to contain critical data for opening project

Solution:
Create project data type and serializer

Limits:
None

EditorStorage
*Moved to src folder

EdgeApp
*Refactored EditorStorage include
*Refactored CreateDockspace call

EditorStorage
*Added var to contain Project

ProjectSerializer
*Created class to serialize and deserialize project files

Inspector
*Refactor EditorStorage include

Project
*Create class to hold project data

ProjectExplorer
*Refactor include for EditorStorage

SceneView
*Refactor include for EditorStorage

RazorImGui
*Added string param Title to CreateDockspace func

## Feat - Editor Can Create New Projects

Problem:
Need functionality in editor to create new projects to define game project settings

Solution:
Add new menu bar with create project dropdown button along with New Project Popup Window

Limits:
Input text for popup does not support deleting text

EdgeApp
*Added CreateDockspace function moved from RazorImGui
*Added logic to draw current popup

ProjectSerializer
*Added creation of project directory and subsequent folders
*Added error checking on Project Param

PopupWindow
*New base class for popupwindows

NewProjectPopupWindow
*New class for New Project Popup Window

RazorImGui
*Removed CreateDockspace function
e287776
