### PR TITLE
43 engine rework engine calls

### DIFF
--- a/Edge/src/EdgeApp.cpp
+++ b/Edge/src/EdgeApp.cpp
@@ -7,7 +7,6 @@
 #include "ProjectExplorer.h"
 #include "Systems/RSEditorCamera.h"
 #include "EditorCamera.h"
-#include "FileIO/ProjectSerializer.h"
 #include "Gui/NewProjectPopupWindow.h"
 #include "Gui/OpenProjectPopupWindow.h"
 
@@ -150,7 +149,7 @@ void Edge::Run()
 
 		Renderer->PollForEvents();
 
-		// TODO runtime
+		
 		Engine.RunSystems();
 
 		Engine.GetGUI().BeginNewFrame();
@@ -249,46 +248,7 @@ void Edge::CreateDockspace(const std::string& Title)
 
 void Edge::OnNewProjectSet()
 {
-	EdgeEditor::Project& LoadedProject = Storage->GetProject();
-	RZ_INFO("Loading up project: " + LoadedProject.ProjectName);
-	const std::string ProjectPath = "../Sandbox";
-	//Load new scene
-	Razor::Ref<Razor::Scene> MainScene = Razor::CreateRef<Razor::Scene>(ProjectPath + LoadedProject.MainScenePath);
-	if (Razor::SceneSerializer::Deserialize(MainScene) == false)
-	{
-		LoadedProject.MainScenePath = "/assets/scenes/Main.rzscn";
-		MainScene = Razor::CreateRef<Razor::Scene>(LoadedProject.MainScenePath);
-		Razor::SceneSerializer::Serialize(MainScene);
-		EdgeEditor::ProjectSerializer::Serialize("../", Razor::CreateRef<EdgeEditor::Project>(LoadedProject));
-	}
-	Razor::Engine::Get().CurrentScene = MainScene;
-	//TODO we haven't dealt with tearing down an old scene and loading a new one yet that's mainly just destroying old entities
-	//Load new dlls
-	// We need to move all Coral code into Razor behind an interface through which we will ask Coral things as we seem to be losing all of our function ptrs to the managed library over the DLL boundary
-	Razor::ScriptInterface& ScriptInterface = Razor::Engine::Get().GetScriptInterface();
-	Razor::ScriptAssembly ScriptBridgeAssembly = ScriptInterface.LoadAssembly(ProjectPath + "/" + LoadedProject.DllDirectory + "/" + "Razor-ScriptBridge.dll", true);
-	Razor::ScriptAssembly GameAssembly = ScriptInterface.LoadAssembly(ProjectPath + "/" + LoadedProject.DllDirectory + "/" + LoadedProject.ProjectName + ".dll", false);
-
-	std::vector<Razor::ScriptType> Types = ScriptInterface.GetTypes(GameAssembly);
-
-	if (!ScriptInterface.GetType(ScriptBridgeAssembly, "Razor.System"))
-	{
-		RZ_ERROR("Could not get System type");
-	}
-
-	for (Razor::ScriptType ScriptType : Types)
-	{
-		/*We are getting the type now however we are struggling to get base type as they are all null for some reason*/
-		RZ_INFO("Script Type {0} and name {1}", ScriptType.id, ScriptType.fullName);
-		RZ_INFO("Script Type Base Type {0} and name {1}", ScriptInterface.GetBaseType(ScriptType).id, ScriptInterface.GetBaseType(ScriptType).fullName);
-		RZ_INFO("Razor System Type Id {0}", ScriptInterface.GetType(ScriptBridgeAssembly, "Razor.System").id);
-		if (ScriptInterface.GetBaseType(ScriptType).id == ScriptInterface.GetType(ScriptBridgeAssembly, "Razor.System").id)
-		{
-			RZ_INFO("Instantiating system type");
-			Razor::ScriptObject TestObject = ScriptInterface.CreateInstance(ScriptType);
-			ScriptInterface.InvokeMethod(TestObject, "Run", 1.0f);
-		}
-	}
-
+	Razor::Engine& Engine = Razor::Engine::Get();
+	Engine.LoadProject(Storage->GetProject());
 	// We need to be able to iterate through types avaliable, create instances of a type, invoke methods on this type, load assemblies
 }

--- a/Edge/src/EdgeApp.cpp
+++ b/Edge/src/EdgeApp.cpp
@@ -124,9 +124,6 @@ void Edge::Run()
 	{
 		std::shared_ptr<Razor::IRenderer> Renderer = Engine.Renderer;
 
-		// TODO this potentially doesn't need to get called here cause we might not be pressing play yet
-		Engine.Step();
-
 		const uint32_t SizeX = (uint32_t)ViewportSize.X;
 		const uint32_t SizeY = (uint32_t)ViewportSize.Y;
 
@@ -134,23 +131,13 @@ void Edge::Run()
 		SceneBuffer->Refresh(SizeX, SizeY);
 		Renderer->SetViewport(0, 0, SizeX, SizeY);
 
-		Renderer->BindFrameBuffer(PickBuffer->GetID());
-		Renderer->ClearBuffer();
-		Engine.RunRenderSystems(PickPipelineConfig);
+		Engine.Render(PickBuffer->GetID(), PickPipelineConfig);
 
 		ProcessInput();
 
-		Renderer->BindFrameBuffer(SceneBuffer->GetID());
-		Renderer->ClearBuffer();
-		Engine.RunRenderSystems(EditorPipelineConfig);
-
-		Renderer->BindFrameBuffer();
-		Renderer->ClearBuffer();
+		Engine.Render(SceneBuffer->GetID(), EditorPipelineConfig);
 
 		Renderer->PollForEvents();
-
-		
-		Engine.RunSystems();
 
 		Engine.GetGUI().BeginNewFrame();
 		CreateDockspace("Edge");
@@ -238,6 +225,18 @@ void Edge::CreateDockspace(const std::string& Title)
 			if (Razor::RazorImGui::MenuItem("Open Project"))
 			{
 				CurrentPopup = new EdgeEditor::OpenProjectPopupWindow(Storage);
+			}
+			Razor::RazorImGui::EndMenu();
+		}
+		if (Razor::RazorImGui::BeginMenu("Run"))
+		{
+			if (Razor::RazorImGui::MenuItem("Play"))
+			{
+				Razor::Engine::Get().RuntimeStart();
+			}
+			if (Razor::RazorImGui::MenuItem("Stop"))
+			{
+				Razor::Engine::Get().RuntimeStop();
 			}
 			Razor::RazorImGui::EndMenu();
 		}

--- a/Edge/src/EditorStorage.h
+++ b/Edge/src/EditorStorage.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <Razor.h>
-#include "Project.h"
 
 namespace EdgeEditor
 {
@@ -14,20 +13,20 @@ namespace EdgeEditor
 		Razor::Ref<Razor::Entity> SelectedEntity;
 		Razor::Model DefaultModel;
 	private:
-		Project CurrentProject;
+		std::string CurrentProjectPath;
 		OnProjectSetDelegate ProjectSetDelegate;
 	public:
 		OnProjectSetDelegate& OnProjectSet()
 		{
 			return ProjectSetDelegate;
 		}
-		Project& GetProject()
+		std::string GetProject()
 		{
-			return CurrentProject;
+			return CurrentProjectPath;
 		}
-		void SetProject(Project& Proj)
+		void SetProject(const std::string& Proj)
 		{
-			CurrentProject = Proj;
+			CurrentProjectPath = Proj;
 			ProjectSetDelegate.Broadcast();
 		}
 	};

--- a/Edge/src/EditorStorage.h
+++ b/Edge/src/EditorStorage.h
@@ -20,7 +20,7 @@ namespace EdgeEditor
 		{
 			return ProjectSetDelegate;
 		}
-		std::string GetProject()
+		const std::string& GetProject() const
 		{
 			return CurrentProjectPath;
 		}

--- a/Edge/src/Gui/NewProjectPopupWindow.cpp
+++ b/Edge/src/Gui/NewProjectPopupWindow.cpp
@@ -1,6 +1,4 @@
 #include "NewProjectPopupWindow.h"
-#include "../FileIO/ProjectSerializer.h"
-#include "../Project.h"
 
 namespace EdgeEditor
 {
@@ -9,16 +7,16 @@ namespace EdgeEditor
 		const std::string MagicalPathToFixWithActualSelectedPathSoon = "../../Sandboxes/";
 
 		bool bIsOpen = true;
-		if (NewProject == nullptr)
+		/*if (NewProject == nullptr)
 		{
 			Open();
-		}
+		}*/
 		if (Razor::RazorImGui::BeginPopupModal("New Project Window", nullptr))
 		{
 			//ImGui::InputText("Project Name", &NewProject->ProjectName);
 			if (Razor::RazorImGui::Button("Create"))
 			{
-				EdgeEditor::ProjectSerializer::Serialize(MagicalPathToFixWithActualSelectedPathSoon, NewProject);
+				//EdgeEditor::ProjectSerializer::Serialize(MagicalPathToFixWithActualSelectedPathSoon, NewProject);
 				/*TODO actually load project up*/
 				Razor::RazorImGui::CloseCurrentPopup();
 			}
@@ -34,7 +32,7 @@ namespace EdgeEditor
 	}
 	void NewProjectPopupWindow::Open()
 	{
-		NewProject = Razor::CreateRef<Project>();
+		//NewProject = Razor::CreateRef<Project>();
 		Razor::RazorImGui::OpenPopup("New Project Window");
 	}
 	void NewProjectPopupWindow::Close()

--- a/Edge/src/Gui/OpenProjectPopupWindow.cpp
+++ b/Edge/src/Gui/OpenProjectPopupWindow.cpp
@@ -1,6 +1,4 @@
 #include "OpenProjectPopupWindow.h"
-#include "../FileIO/ProjectSerializer.h"
-#include "../Project.h"
 #include "../EditorStorage.h"
 
 
@@ -17,9 +15,7 @@ namespace EdgeEditor
 			// TODO will create big old file explorer for now we just wanna have a button we click which directs us to the current Sandbox
 			if (Razor::RazorImGui::Button("Create"))
 			{
-				Razor::Ref<Project> LoadedProject = Razor::CreateRef<Project>();
-				ProjectSerializer::Deserialize("../Sandbox/Sandbox", LoadedProject);
-				Storage->SetProject(*LoadedProject);
+				Storage->SetProject("../Sandbox/Sandbox");
 				Razor::RazorImGui::CloseCurrentPopup();
 			}
 			Razor::RazorImGui::SameLine();

--- a/Razor/src/Razor/Component.h
+++ b/Razor/src/Razor/Component.h
@@ -129,4 +129,12 @@ namespace Razor
 		// MouseBut [Key] -> State (0, 1)
 		// MousePos -> Pos
 	};
+
+	struct ScriptComponent
+	{
+		std::string ClassName;
+
+		ScriptComponent() = default;
+		ScriptComponent(const ScriptComponent&) = default;
+	};
 }

--- a/Razor/src/Razor/Engine.cpp
+++ b/Razor/src/Razor/Engine.cpp
@@ -160,14 +160,19 @@ namespace Razor
 		return ShaderTypeMap[std::string(Type)];
 	}
 
-	void Engine::RunRenderSystems(const RenderPipelineConfig& Config) 
+	void Engine::Render(int32_t targetId, const RenderPipelineConfig& Config) 
 	{
+		Renderer->BindFrameBuffer(targetId);
+		Renderer->ClearBuffer();
 		Coordinator->RunRenderSystems(Config); 
+		Renderer->BindFrameBuffer();
+		Renderer->ClearBuffer();
 	}
 
 	void Engine::RunSystems() 
 	{ 
-		Coordinator->RunSystems(DeltaTime); 
+		Coordinator->RunSystems(DeltaTime);
+		CurrentScene->RunSystems(DeltaTime);
 	}
 
 	std::shared_ptr<Coordinator> Engine::GetCoordinator()
@@ -222,31 +227,42 @@ namespace Razor
 			ProjectSerializer::Serialize("../", LoadedProject);
 		}
 		CurrentScene = MainScene;
-		//TODO we haven't dealt with tearing down an old scene and loading a new one yet that's mainly just destroying old entities
-		//Load new dlls
-		// We need to move all Coral code into Razor behind an interface through which we will ask Coral things as we seem to be losing all of our function ptrs to the managed library over the DLL boundary
+		
 		BridgeAssembly = CreateScope<ScriptAssembly>(ScriptInterface->LoadAssembly(Path + "/" + LoadedProject->DllDirectory + "/" + "Razor-ScriptBridge.dll", true));
 		GameAssembly = CreateScope<ScriptAssembly>(ScriptInterface->LoadAssembly(Path + "/" + LoadedProject->DllDirectory + "/" + LoadedProject->ProjectName + ".dll", false));
+	}
 
-		std::vector<ScriptType> Types = ScriptInterface->GetTypes(*(GameAssembly.get()));
-
-		if (!ScriptInterface->GetType(*(BridgeAssembly.get()), "Razor.System"))
+	void Engine::RuntimeStart()
+	{
+		if(bIsRuntimeRunning.load())
 		{
-			RZ_CORE_ERROR("Could not get System type");
+			RZ_CORE_WARN("Runtime is already running");
+			return;
 		}
+		RZ_CORE_INFO("Starting Runtime");
+		bIsRuntimeRunning.store(true);
+		RuntimeThread = std::thread(&Engine::RunRuntime, this);
+	}
 
-		for (Razor::ScriptType ScriptType : Types)
+	void Engine::RunRuntime()
+	{
+		while (bIsRuntimeRunning)
 		{
-			/*We are getting the type now however we are struggling to get base type as they are all null for some reason*/
-			RZ_CORE_INFO("Script Type {0} and name {1}", ScriptType.id, ScriptType.fullName);
-			RZ_CORE_INFO("Script Type Base Type {0} and name {1}", ScriptInterface->GetBaseType(ScriptType).id, ScriptInterface->GetBaseType(ScriptType).fullName);
-			RZ_CORE_INFO("Razor System Type Id {0}", ScriptInterface->GetType(*(BridgeAssembly.get()), "Razor.System").id);
-			if (ScriptInterface->GetBaseType(ScriptType).id == ScriptInterface->GetType(*(BridgeAssembly.get()), "Razor.System").id)
-			{
-				RZ_INFO("Instantiating system type");
-				Razor::ScriptObject TestObject = ScriptInterface->CreateInstance(ScriptType);
-				ScriptInterface->InvokeMethod(TestObject, "Run", 1.0f);
-			}
+			Step();
+			//Somehow pick up input and forward?
+			//ProcessInputForGame()
+			RunSystems();
+		}
+		RZ_CORE_INFO("Exiting Runtime Thread");
+	}
+
+	void Engine::RuntimeStop()
+	{
+		RZ_CORE_INFO("Stopping Runtime");
+		bIsRuntimeRunning.store(false);
+		if(RuntimeThread.joinable())
+		{
+			RuntimeThread.join();
 		}
 	}
 }

--- a/Razor/src/Razor/Engine.cpp
+++ b/Razor/src/Razor/Engine.cpp
@@ -31,6 +31,8 @@
 #include "../Platform/Generic/ITimeProvider.h"
 #include "Log.h"
 #include "Scripting/ScriptInterface.h"
+#include "Scene/Project.h"
+#include "IO/File/ProjectSerializer.h"
 
 namespace Razor
 {
@@ -191,5 +193,60 @@ namespace Razor
 	ScriptInterface& Engine::GetScriptInterface()
 	{
 		return *ScriptInterface;
+	}
+
+	void Engine::LoadProject(const std::string& ProjectPath)
+	{
+		if (ProjectPath.empty())
+		{
+			RZ_CORE_ERROR("Project path is empty");
+			return;
+		}
+
+		if (LoadedProject == nullptr)
+		{
+			LoadedProject = CreateRef<Project>();
+		}
+
+		ProjectSerializer::Deserialize(ProjectPath, LoadedProject);
+
+		RZ_CORE_INFO("Loading up project: " + LoadedProject->ProjectName);
+		const std::string Path = "../Sandbox";
+		//Load new scene
+		Ref<Scene> MainScene = CreateRef<Scene>(Path + LoadedProject->MainScenePath);
+		if (SceneSerializer::Deserialize(MainScene) == false)
+		{
+			LoadedProject->MainScenePath = "/assets/scenes/Main.rzscn";
+			MainScene = CreateRef<Scene>(LoadedProject->MainScenePath);
+			SceneSerializer::Serialize(MainScene);
+			ProjectSerializer::Serialize("../", LoadedProject);
+		}
+		CurrentScene = MainScene;
+		//TODO we haven't dealt with tearing down an old scene and loading a new one yet that's mainly just destroying old entities
+		//Load new dlls
+		// We need to move all Coral code into Razor behind an interface through which we will ask Coral things as we seem to be losing all of our function ptrs to the managed library over the DLL boundary
+		BridgeAssembly = CreateScope<ScriptAssembly>(ScriptInterface->LoadAssembly(Path + "/" + LoadedProject->DllDirectory + "/" + "Razor-ScriptBridge.dll", true));
+		GameAssembly = CreateScope<ScriptAssembly>(ScriptInterface->LoadAssembly(Path + "/" + LoadedProject->DllDirectory + "/" + LoadedProject->ProjectName + ".dll", false));
+
+		std::vector<ScriptType> Types = ScriptInterface->GetTypes(*(GameAssembly.get()));
+
+		if (!ScriptInterface->GetType(*(BridgeAssembly.get()), "Razor.System"))
+		{
+			RZ_CORE_ERROR("Could not get System type");
+		}
+
+		for (Razor::ScriptType ScriptType : Types)
+		{
+			/*We are getting the type now however we are struggling to get base type as they are all null for some reason*/
+			RZ_CORE_INFO("Script Type {0} and name {1}", ScriptType.id, ScriptType.fullName);
+			RZ_CORE_INFO("Script Type Base Type {0} and name {1}", ScriptInterface->GetBaseType(ScriptType).id, ScriptInterface->GetBaseType(ScriptType).fullName);
+			RZ_CORE_INFO("Razor System Type Id {0}", ScriptInterface->GetType(*(BridgeAssembly.get()), "Razor.System").id);
+			if (ScriptInterface->GetBaseType(ScriptType).id == ScriptInterface->GetType(*(BridgeAssembly.get()), "Razor.System").id)
+			{
+				RZ_INFO("Instantiating system type");
+				Razor::ScriptObject TestObject = ScriptInterface->CreateInstance(ScriptType);
+				ScriptInterface->InvokeMethod(TestObject, "Run", 1.0f);
+			}
+		}
 	}
 }

--- a/Razor/src/Razor/Engine.cpp
+++ b/Razor/src/Razor/Engine.cpp
@@ -213,11 +213,15 @@ namespace Razor
 			LoadedProject = CreateRef<Project>();
 		}
 
-		ProjectSerializer::Deserialize(ProjectPath, LoadedProject);
-
-		RZ_CORE_INFO("Loading up project: " + LoadedProject->ProjectName);
 		const std::string Path = "../Sandbox";
-		//Load new scene
+
+		ProjectSerializer::Deserialize(ProjectPath, LoadedProject);
+		RZ_CORE_INFO("Loading up project: {0}", LoadedProject->ProjectName);
+		// TODO move assembly holding into ScriptEngine
+		BridgeAssembly = CreateScope<ScriptAssembly>(ScriptInterface->LoadAssembly(Path + "/" + LoadedProject->DllDirectory + "/" + "Razor-ScriptBridge.dll", true));
+		GameAssembly = CreateScope<ScriptAssembly>(ScriptInterface->LoadAssembly(Path + "/" + LoadedProject->DllDirectory + "/" + LoadedProject->ProjectName + ".dll", false));
+
+		// Load main scene
 		Ref<Scene> MainScene = CreateRef<Scene>(Path + LoadedProject->MainScenePath);
 		if (SceneSerializer::Deserialize(MainScene) == false)
 		{
@@ -227,9 +231,6 @@ namespace Razor
 			ProjectSerializer::Serialize("../", LoadedProject);
 		}
 		CurrentScene = MainScene;
-		
-		BridgeAssembly = CreateScope<ScriptAssembly>(ScriptInterface->LoadAssembly(Path + "/" + LoadedProject->DllDirectory + "/" + "Razor-ScriptBridge.dll", true));
-		GameAssembly = CreateScope<ScriptAssembly>(ScriptInterface->LoadAssembly(Path + "/" + LoadedProject->DllDirectory + "/" + LoadedProject->ProjectName + ".dll", false));
 	}
 
 	void Engine::RuntimeStart()

--- a/Razor/src/Razor/Engine.h
+++ b/Razor/src/Razor/Engine.h
@@ -5,6 +5,8 @@
 #include "Core.h"
 #include "../Platform/Generic/IPlatformIO.h"
 #include "Scene/Project.h"
+#include <thread>
+#include <atomic>
 
 namespace Razor
 {
@@ -88,7 +90,7 @@ namespace Razor
 		* 
 		* @param Config - The pipeline configuration we want to run with this render
 		*/
-		void RunRenderSystems(const RenderPipelineConfig& Config);
+		void Render(int32_t targetId, const RenderPipelineConfig& Config);
 		/**
 		* Getter function for the RazorImGui object
 		* 
@@ -154,11 +156,15 @@ namespace Razor
 
 		void LoadProject(const std::string& ProjectPath);
 
+		void RuntimeStart();
+		void RuntimeStop();
+
 		Ref<Scene> CurrentScene; /** Ref to the current scene we have*/
 
 	private:
 		
 		void RenderImGui(uint64_t SceneTexture);
+		void RunRuntime();
 
 		std::unique_ptr<Window> EngineWindow;
 		std::shared_ptr<Coordinator> Coordinator;
@@ -175,5 +181,8 @@ namespace Razor
 		Ref<Project> LoadedProject;
 		Scope<ScriptAssembly> BridgeAssembly;
 		Scope<ScriptAssembly> GameAssembly;
+
+		std::atomic<bool> bIsRuntimeRunning { false };
+		std::thread RuntimeThread;
 	};
 }

--- a/Razor/src/Razor/Engine.h
+++ b/Razor/src/Razor/Engine.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include "Core.h"
 #include "../Platform/Generic/IPlatformIO.h"
+#include "Scene/Project.h"
 
 namespace Razor
 {
@@ -20,6 +21,8 @@ namespace Razor
 
 	struct Light;
 	struct RenderStageConfig;
+
+	struct ScriptAssembly;
 
 	using RenderPipelineConfig = std::vector<RenderStageConfig>;
 
@@ -149,6 +152,8 @@ namespace Razor
 
 		ScriptInterface& GetScriptInterface();
 
+		void LoadProject(const std::string& ProjectPath);
+
 		Ref<Scene> CurrentScene; /** Ref to the current scene we have*/
 
 	private:
@@ -167,5 +172,8 @@ namespace Razor
 		std::unique_ptr<IPlatformIO> PlatformIO;
 		std::unique_ptr<ITimeProvider> TimeProvider; /** Generic object to provide time functionality */
 		std::unique_ptr<ScriptInterface> ScriptInterface;
+		Ref<Project> LoadedProject;
+		Scope<ScriptAssembly> BridgeAssembly;
+		Scope<ScriptAssembly> GameAssembly;
 	};
 }

--- a/Razor/src/Razor/IO/File/ProjectSerializer.cpp
+++ b/Razor/src/Razor/IO/File/ProjectSerializer.cpp
@@ -1,23 +1,25 @@
 #include "ProjectSerializer.h"
-#include "../Project.h"
+#include "../../Scene/Project.h"
+#include "../../Log.h"
+#include "../YamlWrapper.h"
 #include <fstream>
 #include <filesystem>
 
 
-namespace EdgeEditor
+namespace Razor
 {
 
 	void ProjectSerializer::Serialize(const std::string& Path, Razor::Ref<Project> Project)
 	{
 		if (Project == nullptr)
 		{
-			RZ_ERROR("ProjectSerializer::Serialize Error: Project Ptr passed in was null");
+			RZ_CORE_ERROR("ProjectSerializer::Serialize Error: Project Ptr passed in was null");
 			return;
 		}
 
 		if (Project->ProjectName == "")
 		{
-			RZ_ERROR("ProjectSerializer::Serialize Error: Project Name cannot be an empty string");
+			RZ_CORE_ERROR("ProjectSerializer::Serialize Error: Project Name cannot be an empty string");
 			return;
 		}
 
@@ -38,17 +40,17 @@ namespace EdgeEditor
 		Project->AssetDirectory = AssetFolderPath;
 		Project->DllDirectory = DllFolderPath;
 
-		Razor::YamlEmitter* Out =  Razor::yaml_emitter_new();
-		Razor::yaml_emitter_begin_map(Out);
-		Razor::yaml_emitter_key(Out, "ProjectName");
-		Razor::yaml_emitter_value_string(Out, Project->ProjectName.c_str());
-		Razor::yaml_emitter_key(Out, "AssetDirectory");
-		Razor::yaml_emitter_value_string(Out, Project->AssetDirectory.c_str());
-		Razor::yaml_emitter_key(Out, "DllDirectory");
-		Razor::yaml_emitter_value_string(Out, Project->DllDirectory.c_str());
-		Razor::yaml_emitter_key(Out, "MainScenePath");
-		Razor::yaml_emitter_value_string(Out, Project->MainScenePath.c_str());
-		Razor::yaml_emitter_end_map(Out);
+		YamlEmitter* Out =  yaml_emitter_new();
+		yaml_emitter_begin_map(Out);
+		yaml_emitter_key(Out, "ProjectName");
+		yaml_emitter_value_string(Out, Project->ProjectName.c_str());
+		yaml_emitter_key(Out, "AssetDirectory");
+		yaml_emitter_value_string(Out, Project->AssetDirectory.c_str());
+		yaml_emitter_key(Out, "DllDirectory");
+		yaml_emitter_value_string(Out, Project->DllDirectory.c_str());
+		yaml_emitter_key(Out, "MainScenePath");
+		yaml_emitter_value_string(Out, Project->MainScenePath.c_str());
+		yaml_emitter_end_map(Out);
 
 
 		std::filesystem::create_directory(ProjectFolderPath);
@@ -58,7 +60,7 @@ namespace EdgeEditor
 		std::ofstream FOut(PathPlusExt.c_str());
 		const char* ErrorMsg = new char(' ');
 		std::perror(ErrorMsg);
-		RZ_WARN("Error Msg: {0}", ErrorMsg);
+		RZ_CORE_WARN("Error Msg: {0}", ErrorMsg);
 		FOut << Razor::yaml_emitter_cstr(Out);
 		FOut.close();
 	}
@@ -74,17 +76,18 @@ namespace EdgeEditor
 		}
 		catch (std::exception e)
 		{
-			RZ_ERROR("Failed to load .proj file '{0}'\n	{1}", PathPlusExt, e.what());
+			RZ_CORE_ERROR("Failed to load .proj file '{0}'\n	{1}", PathPlusExt, e.what());
 			return;
 		}
 
 		if (!Razor::yaml_get_child(Data, "ProjectName"))
 		{
-			RZ_ERROR("Incomplete .proj file missing 'ProjectName' key");
+			RZ_CORE_ERROR("Incomplete .proj file missing 'ProjectName' key");
 			return;
 		}
 
 		OutProject->ProjectName = Razor::yaml_as_string(Razor::yaml_get_child(Data, "ProjectName"));
+		RZ_CORE_ERROR("ProjectName {0}", OutProject->ProjectName);
 		OutProject->AssetDirectory = Razor::yaml_as_string(Razor::yaml_get_child(Data, "AssetDirectory"));
 		OutProject->DllDirectory = Razor::yaml_as_string(Razor::yaml_get_child(Data, "DllDirectory"));
 		OutProject->MainScenePath = Razor::yaml_as_string(Razor::yaml_get_child(Data, "MainScenePath"));

--- a/Razor/src/Razor/IO/File/ProjectSerializer.cpp
+++ b/Razor/src/Razor/IO/File/ProjectSerializer.cpp
@@ -87,7 +87,6 @@ namespace Razor
 		}
 
 		OutProject->ProjectName = Razor::yaml_as_string(Razor::yaml_get_child(Data, "ProjectName"));
-		RZ_CORE_ERROR("ProjectName {0}", OutProject->ProjectName);
 		OutProject->AssetDirectory = Razor::yaml_as_string(Razor::yaml_get_child(Data, "AssetDirectory"));
 		OutProject->DllDirectory = Razor::yaml_as_string(Razor::yaml_get_child(Data, "DllDirectory"));
 		OutProject->MainScenePath = Razor::yaml_as_string(Razor::yaml_get_child(Data, "MainScenePath"));

--- a/Razor/src/Razor/IO/File/ProjectSerializer.h
+++ b/Razor/src/Razor/IO/File/ProjectSerializer.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "Razor.h"
+#include "../../Core.h"
 
-namespace EdgeEditor
+namespace Razor
 {
 	struct Project;
 

--- a/Razor/src/Razor/IO/YamlWrapper.cpp
+++ b/Razor/src/Razor/IO/YamlWrapper.cpp
@@ -60,6 +60,29 @@ namespace YAML
     };
 
     template<>
+    struct convert<Razor::Vector2>
+    {
+        static Node encode(const Razor::Vector2& rhs)
+        {
+            Node node;
+            node.push_back(rhs.X);
+            node.push_back(rhs.Y);
+            node.SetStyle(EmitterStyle::Flow);
+            return node;
+        }
+
+        static bool decode(const Node& node, Razor::Vector2& rhs)
+        {
+            if (!node.IsSequence() || node.size() != 2)
+                return false;
+
+            rhs.X = node[0].as<float>();
+            rhs.Y = node[1].as<float>();
+            return true;
+        }
+    };
+
+    template<>
     struct convert<glm::vec2>
     {
         static Node encode(const glm::vec2& rhs)
@@ -359,11 +382,47 @@ namespace Razor
         }
     }
 
+    char yaml_as_char(YamlNode* node)
+    {
+        if (!node) return 0;
+        auto impl = reinterpret_cast<YamlNodeImpl*>(node);
+        try {
+            return impl->node.as<char>();
+        }
+        catch (...) {
+            return 0;
+        }
+    }
+
     int yaml_as_int(YamlNode* node, int default_val) {
         if (!node) return default_val;
         auto impl = reinterpret_cast<YamlNodeImpl*>(node);
         try {
             return impl->node.as<int>();
+        }
+        catch (...) {
+            return default_val;
+        }
+    }
+
+    uint32_t yaml_as_int32(YamlNode* node, uint32_t default_val) {
+        if (!node) return default_val;
+        auto impl = reinterpret_cast<YamlNodeImpl*>(node);
+        try {
+            return impl->node.as<uint32_t>();
+        }
+        catch (...) {
+            return default_val;
+        }
+    }
+
+    float yaml_as_float(YamlNode* node, float default_val)
+    {
+        if (!node) return default_val;
+        auto impl = reinterpret_cast<YamlNodeImpl*>(node);
+        try {
+            impl->cache = impl->node.as<float>();
+            return impl->node.as<float>();
         }
         catch (...) {
             return default_val;
@@ -389,6 +448,23 @@ namespace Razor
         }
         catch (...) {
             return default_val;
+        }
+    }
+
+    Vector2 yaml_as_vec2(YamlNode* node)
+    {
+        if (!node)
+        {
+            return Vector2();
+        }
+        auto impl = reinterpret_cast<YamlNodeImpl*>(node);
+        try
+        {
+            return impl->node.as<Vector2>();
+        }
+        catch (...)
+        {
+            return Vector2();
         }
     }
 
@@ -504,11 +580,19 @@ namespace Razor
         if (emitter && value) reinterpret_cast<YamlEmitterImpl*>(emitter)->out << YAML::Value << value;
     }
 
+    void yaml_emitter_value_char(YamlEmitter* emitter, char value) {
+        if (emitter && value) reinterpret_cast<YamlEmitterImpl*>(emitter)->out << YAML::Value << value;
+    }
+
     void yaml_emitter_value_int(YamlEmitter* emitter, int value) {
         if (emitter) reinterpret_cast<YamlEmitterImpl*>(emitter)->out << YAML::Value << value;
     }
 
     void yaml_emitter_value_double(YamlEmitter* emitter, double value) {
+        if (emitter) reinterpret_cast<YamlEmitterImpl*>(emitter)->out << YAML::Value << value;
+    }
+
+    void yaml_emitter_value_float(YamlEmitter* emitter, float value) {
         if (emitter) reinterpret_cast<YamlEmitterImpl*>(emitter)->out << YAML::Value << value;
     }
 

--- a/Razor/src/Razor/IO/YamlWrapper.h
+++ b/Razor/src/Razor/IO/YamlWrapper.h
@@ -32,9 +32,13 @@ namespace Razor
 
 	// Query scalar types
 	RAZOR_API std::string yaml_as_string(YamlNode* node);
+	RAZOR_API char yaml_as_char(YamlNode* node);
 	RAZOR_API int yaml_as_int(YamlNode* node, int default_val);
+	RAZOR_API uint32_t yaml_as_int32(YamlNode* node, uint32_t default_val);
+	RAZOR_API float yaml_as_float(YamlNode* node, float default_val);
 	RAZOR_API double yaml_as_double(YamlNode* node, double default_val);
-	RAZOR_API int yaml_as_bool(YamlNode* node, int default_val);
+	RAZOR_API int yaml_as_bool(YamlNode* node, int default_val); 
+	RAZOR_API Vector2 yaml_as_vec2(YamlNode* node);
 	RAZOR_API Vector3 yaml_as_vec3(YamlNode* node);
 	RAZOR_API ModelInfo yaml_as_modelinfo(YamlNode* node);
 
@@ -60,8 +64,10 @@ namespace Razor
 	RAZOR_API void yaml_emitter_key(YamlEmitter* emitter, const char* key);
 
 	RAZOR_API void yaml_emitter_value_string(YamlEmitter* emitter, const char* value);
+	RAZOR_API void yaml_emitter_value_char(YamlEmitter* emitter, char value);
 	RAZOR_API void yaml_emitter_value_int(YamlEmitter* emitter, int value);
 	RAZOR_API void yaml_emitter_value_double(YamlEmitter* emitter, double value);
+	RAZOR_API void yaml_emitter_value_float(YamlEmitter* emitter, float value);
 	RAZOR_API void yaml_emitter_value_bool(YamlEmitter* emitter, int value);
 	RAZOR_API void yaml_emitter_value_seq(YamlEmitter* emitter);
 	RAZOR_API void yaml_emitter_value_int32(YamlEmitter* emitter, uint32_t value);

--- a/Razor/src/Razor/Renderer/Model.h
+++ b/Razor/src/Razor/Renderer/Model.h
@@ -38,11 +38,11 @@ namespace Razor
 		}
 
 		MeshData(std::vector<Vertex> Vertices, std::vector<unsigned int> Indices, std::vector<Texture> Textures, unsigned int MaterialID)
+			: Vertices(Vertices),
+			  Indices(Indices), 
+			  Textures(Textures), 
+			  MaterialId(MaterialID)
 		{
-			this->Vertices = Vertices;
-			this->Indices = Indices;
-			this->Textures = Textures;
-			MaterialId = MaterialID;
 		}
 
 		std::vector<Vertex> Vertices;

--- a/Razor/src/Razor/Scene/Project.h
+++ b/Razor/src/Razor/Scene/Project.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-namespace EdgeEditor
+namespace Razor
 {
 	/**
 	* Struct to hold data about this game project

--- a/Razor/src/Razor/Scene/Scene.cpp
+++ b/Razor/src/Razor/Scene/Scene.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include "../Engine.h"
 #include "../Scripting/ScriptInterface.h"
+#include "../Log.h"
 
 namespace Razor
 {
@@ -38,20 +39,9 @@ namespace Razor
 		}
 	}
 
-	void Scene::CreateSystemObject()
+	void Scene::CreateSystemObject(const Razor::ScriptType& Type)
 	{
-		/*for (Razor::ScriptType ScriptType : Types)
-		{
-			RZ_CORE_INFO("Script Type {0} and name {1}", ScriptType.id, ScriptType.fullName);
-			RZ_CORE_INFO("Script Type Base Type {0} and name {1}", ScriptInterface->GetBaseType(ScriptType).id, ScriptInterface->GetBaseType(ScriptType).fullName);
-			RZ_CORE_INFO("Razor System Type Id {0}", ScriptInterface->GetType(*(BridgeAssembly.get()), "Razor.System").id);
-			if (ScriptInterface->GetBaseType(ScriptType).id == ScriptInterface->GetType(*(BridgeAssembly.get()), "Razor.System").id)
-			{
-				RZ_INFO("Instantiating system type");
-				Razor::ScriptObject TestObject = ScriptInterface->CreateInstance(ScriptType);
-
-				// 2 real questions here is how do we hold all these system objects and how do we give them the entities to work with
-			}
-		}*/
+		RZ_CORE_INFO("Instantiating system type {0}", Type.fullName);
+		SystemObjects.push_back(Engine::Get().GetScriptInterface().CreateInstance(Type));
 	}
 }

--- a/Razor/src/Razor/Scene/Scene.cpp
+++ b/Razor/src/Razor/Scene/Scene.cpp
@@ -2,6 +2,8 @@
 #include "../Core/Entity.h"
 #include "../Component.h"
 #include <string>
+#include "../Engine.h"
+#include "../Scripting/ScriptInterface.h"
 
 namespace Razor
 {
@@ -28,4 +30,28 @@ namespace Razor
 		return Entt->HasComponent<Transform>() ? Entt : nullptr;
 	}
 	
+	void Scene::RunSystems(float DeltaTime)
+	{
+		for (auto system : SystemObjects)
+		{
+			Engine::Get().GetScriptInterface().InvokeMethod(system, "Run", DeltaTime);
+		}
+	}
+
+	void Scene::CreateSystemObject()
+	{
+		/*for (Razor::ScriptType ScriptType : Types)
+		{
+			RZ_CORE_INFO("Script Type {0} and name {1}", ScriptType.id, ScriptType.fullName);
+			RZ_CORE_INFO("Script Type Base Type {0} and name {1}", ScriptInterface->GetBaseType(ScriptType).id, ScriptInterface->GetBaseType(ScriptType).fullName);
+			RZ_CORE_INFO("Razor System Type Id {0}", ScriptInterface->GetType(*(BridgeAssembly.get()), "Razor.System").id);
+			if (ScriptInterface->GetBaseType(ScriptType).id == ScriptInterface->GetType(*(BridgeAssembly.get()), "Razor.System").id)
+			{
+				RZ_INFO("Instantiating system type");
+				Razor::ScriptObject TestObject = ScriptInterface->CreateInstance(ScriptType);
+
+				// 2 real questions here is how do we hold all these system objects and how do we give them the entities to work with
+			}
+		}*/
+	}
 }

--- a/Razor/src/Razor/Scene/Scene.cpp
+++ b/Razor/src/Razor/Scene/Scene.cpp
@@ -33,7 +33,7 @@ namespace Razor
 	
 	void Scene::RunSystems(float DeltaTime)
 	{
-		for (auto system : SystemObjects)
+		for (const auto& system : SystemObjects)
 		{
 			Engine::Get().GetScriptInterface().InvokeMethod(system, "Run", DeltaTime);
 		}

--- a/Razor/src/Razor/Scene/Scene.h
+++ b/Razor/src/Razor/Scene/Scene.h
@@ -7,6 +7,7 @@ namespace Razor
 {
 	class Entity;
 	struct ScriptObject;
+	struct ScriptType;
 
 	class RAZOR_API Scene
 	{
@@ -32,7 +33,7 @@ namespace Razor
 		}
 
 		void RunSystems(float DeltaTime);
-		void CreateSystemObject();
+		void CreateSystemObject(const Razor::ScriptType& Type);
 
 		entt::registry registry;
 	private:

--- a/Razor/src/Razor/Scene/Scene.h
+++ b/Razor/src/Razor/Scene/Scene.h
@@ -1,10 +1,12 @@
 #pragma once
 #include <entt/entt.hpp>
 #include "../Core.h"
+#include <vector>
 
 namespace Razor
 {
 	class Entity;
+	struct ScriptObject;
 
 	class RAZOR_API Scene
 	{
@@ -29,9 +31,13 @@ namespace Razor
 			return registry.get<T>(Entity);
 		}
 
+		void RunSystems(float DeltaTime);
+		void CreateSystemObject();
+
 		entt::registry registry;
 	private:
 		std::string FilePath;
+		std::vector<ScriptObject> SystemObjects;
 	};
 }
 

--- a/Razor/src/Razor/Scene/SceneSerializer.cpp
+++ b/Razor/src/Razor/Scene/SceneSerializer.cpp
@@ -6,9 +6,12 @@
 #include "../Utils/Vector.h"
 #include "../Core/Entity.h"
 #include "Scene.h"
+#include "../Scripting/ScriptEngine.h"
+#include "../Assert.h"
 
 namespace Razor
 {
+
 	Vector3 ToVec3(const glm::vec3& Vec)
 	{
 		return Vector3(Vec.x, Vec.y, Vec.z);
@@ -50,6 +53,73 @@ namespace Razor
 		//	Out << YAML::EndSeq;
 		//	Out << YAML::EndMap;
 		//}
+		if (InEntity.HasComponent<ScriptComponent>())
+		{
+			auto& scriptComponent = InEntity.GetComponent<ScriptComponent>();
+
+			yaml_emitter_key(Out, "ScriptComponent");
+			yaml_emitter_begin_map(Out); // ScriptComponent
+			yaml_emitter_key(Out, "ClassName");
+			yaml_emitter_value_string(Out, scriptComponent.ClassName.c_str());
+
+			// Fields
+			Ref<ScriptClass> entityClass = ScriptEngine::GetEntityClass(scriptComponent.ClassName);
+			const auto& fields = entityClass->GetFields();
+			if (fields.size() > 0)
+			{
+				yaml_emitter_key(Out, "ScriptFields");
+				yaml_emitter_value_string(Out, "");
+				yaml_emitter_begin_seq(Out);
+				auto& entityFields = ScriptEngine::GetScriptFieldMap(InEntity);
+				for (const auto& [name, field] : fields)
+				{
+					if (entityFields.find(name) == entityFields.end())
+						continue;
+
+					yaml_emitter_begin_map(Out); // ScriptField
+					yaml_emitter_key(Out, "Name");
+					yaml_emitter_value_string(Out, name.c_str());
+					yaml_emitter_key(Out, "Type");
+					yaml_emitter_value_string(Out, Utils::ScriptFieldTypeToString(field.GetType()));
+
+					yaml_emitter_key(Out, "Data");
+					yaml_emitter_value_string(Out, "");
+					ScriptFieldInstance& scriptField = entityFields.at(name);
+
+					switch (field.GetType())
+					{
+					case ScriptFieldType::Float:
+						yaml_emitter_value_float(Out, scriptField.GetValue<float>());
+						break;
+					case ScriptFieldType::Double:
+						yaml_emitter_value_double(Out, scriptField.GetValue<double>());
+						break;
+					case ScriptFieldType::Bool:
+						yaml_emitter_value_bool(Out, scriptField.GetValue<bool>());
+						break;
+					case ScriptFieldType::Char:
+						yaml_emitter_value_char(Out, scriptField.GetValue<char>());
+						break;
+					case ScriptFieldType::Int:
+						yaml_emitter_value_int(Out, scriptField.GetValue<int>());
+						break;
+					case ScriptFieldType::Vector2:
+						yaml_emitter_value_vec2(Out, scriptField.GetValue<Vector2>());
+						break;
+					case ScriptFieldType::Vector3:
+						yaml_emitter_value_vec3(Out, scriptField.GetValue<Vector3>());
+						break;
+					case ScriptFieldType::Entity:
+						yaml_emitter_value_int32(Out, scriptField.GetValue<uint32_t>());
+						break;
+					}
+					yaml_emitter_end_map(Out); // ScriptFields
+				}
+				yaml_emitter_end_seq(Out);
+			}
+
+			yaml_emitter_end_map(Out); // ScriptComponent
+		}
 
 		yaml_emitter_end_map(Out);
 	}
@@ -126,25 +196,115 @@ namespace Razor
 		{
 			for (auto EntityNode : yaml_get_children(Data, "Entities"))
 			{
-				Ref<Entity> DeserializedEntity = OutScene->CreateEntity();
-				auto TransformComponent = yaml_get_child(Data, "Transform");
-				if (TransformComponent)
-				{
-					glm::vec3 Position = ToGVec3(yaml_as_vec3(yaml_get_child(TransformComponent, "Position")));
-					glm::vec3 Rotation = ToGVec3(yaml_as_vec3(yaml_get_child(TransformComponent, "Rotation")));
-					glm::vec3 Scale = ToGVec3(yaml_as_vec3(yaml_get_child(TransformComponent, "Scale")));
-					Transform EntityTransform = { Position, Scale, Rotation };
-					DeserializedEntity->AddComponent<Transform>(EntityTransform);
-				}
-				//auto MeshComponent = EntityNode["Mesh"];
-				/*if (MeshComponent)
-				{
-					std::vector<MeshData> Data = MeshComponent["Data"].as<std::vector<MeshData>>();
-					Mesh EntityMesh = { Data };
-					DeserializedEntity->AddComponent<Mesh>(EntityMesh);
-				}*/
+				
 			}
 		}
 		return true;
+	}
+
+	void SceneSerializer::DeserializeEntity(YamlNode* EntityNode, Ref<Scene> OutScene)
+	{
+		Ref<Entity> DeserializedEntity = OutScene->CreateEntity();
+		auto TransformComponent = yaml_get_child(EntityNode, "Transform");
+		if (TransformComponent)
+		{
+			glm::vec3 Position = ToGVec3(yaml_as_vec3(yaml_get_child(TransformComponent, "Position")));
+			glm::vec3 Rotation = ToGVec3(yaml_as_vec3(yaml_get_child(TransformComponent, "Rotation")));
+			glm::vec3 Scale = ToGVec3(yaml_as_vec3(yaml_get_child(TransformComponent, "Scale")));
+			Transform EntityTransform = { Position, Scale, Rotation };
+			DeserializedEntity->AddComponent<Transform>(EntityTransform);
+		}
+		auto ScriptComponent = yaml_get_child(EntityNode, "ScriptComponent");
+		if (ScriptComponent)
+		{
+			Razor::ScriptComponent& sc = DeserializedEntity->AddComponent<Razor::ScriptComponent>();
+			sc.ClassName = yaml_as_string(yaml_get_child(ScriptComponent, "ClassName"));
+			YamlNode* Fields = yaml_get_child(ScriptComponent, "ScriptFields");
+			if (Fields)
+			{
+				Ref<ScriptClass> componentClass = ScriptEngine::GetEntityClass(sc.ClassName);
+				if (componentClass)
+				{
+					const auto& classFields = componentClass->GetFields();
+					ScriptFieldMap& entityFields = ScriptEngine::GetScriptFieldMap(*DeserializedEntity);
+
+					for (YamlNode* scriptField : yaml_get_children(ScriptComponent, "ScriptFields"))
+					{
+						std::string name = yaml_as_string(yaml_get_child(scriptField, "Name"));
+						std::string typeString = yaml_as_string(yaml_get_child(scriptField, "Type"));
+						ScriptFieldType type = Utils::ScriptFieldTypeFromString(typeString);
+
+						ScriptFieldInstance& fieldInstance = entityFields[name];
+
+						// TODO(Yan): turn this assert into Hazelnut log warning
+						RZ_CORE_ASSERT(classFields.find(name) != classFields.end());
+
+						if (classFields.find(name) == classFields.end())
+							continue;
+
+						fieldInstance.Field = classFields.at(name);
+
+						switch (type)
+						{
+						case ScriptFieldType::Float:                   
+							{                                                  
+								float data = yaml_as_float(yaml_get_child(scriptField, "Data"), 0.0f);    
+								fieldInstance.SetValue(data);                  
+								break;                                         
+							}
+						case ScriptFieldType::Double:
+						{
+							double data = yaml_as_double(yaml_get_child(scriptField, "Data"), 0.0);
+							fieldInstance.SetValue(data);
+							break;
+						}
+						case ScriptFieldType::Bool:
+						{
+							bool data = yaml_as_bool(yaml_get_child(scriptField, "Data"), false);
+							fieldInstance.SetValue(data);
+							break;
+						}
+						case ScriptFieldType::Char:
+						{
+							char data = yaml_as_char(yaml_get_child(scriptField, "Data"));
+							fieldInstance.SetValue(data);
+							break;
+						}
+						case ScriptFieldType::Int:
+						{
+							int data = yaml_as_int(yaml_get_child(scriptField, "Data"), 0);
+							fieldInstance.SetValue(data);
+							break;
+						}
+						case ScriptFieldType::Vector2:
+						{
+							Vector2 data = yaml_as_vec2(yaml_get_child(scriptField, "Data"));
+							fieldInstance.SetValue(data);
+							break;
+						}
+						case ScriptFieldType::Vector3:
+						{
+							Vector3 data = yaml_as_vec3(yaml_get_child(scriptField, "Data"));
+							fieldInstance.SetValue(data);
+							break;
+						}
+						case ScriptFieldType::Entity:
+						{
+							uint32_t data = yaml_as_int32(yaml_get_child(scriptField, "Data"), 0);
+							fieldInstance.SetValue(data);
+							break;
+						}
+						}
+					}
+				}
+			}
+		}
+		//auto MeshComponent = EntityNode["Mesh"];
+		/*if (MeshComponent)
+		{
+			std::vector<MeshData> Data = MeshComponent["Data"].as<std::vector<MeshData>>();
+			Mesh EntityMesh = { Data };
+			DeserializedEntity->AddComponent<Mesh>(EntityMesh);
+		}*/
 	}
 }

--- a/Razor/src/Razor/Scene/SceneSerializer.h
+++ b/Razor/src/Razor/Scene/SceneSerializer.h
@@ -5,6 +5,7 @@ namespace Razor
 {
 	class IYamlWrapper;
 	struct YamlEmitter;
+	struct YamlNode;
 	class Scene;
 	class Entity;
 
@@ -16,6 +17,7 @@ namespace Razor
 
 	private:
 		static void SerializeEntity(YamlEmitter* Out, Entity InEntity);
+		static void DeserializeEntity(YamlNode* EntityNode, Ref<Scene> OutScene);
 	};
 }
 

--- a/Razor/src/Razor/Scripting/ScriptEngine.cpp
+++ b/Razor/src/Razor/Scripting/ScriptEngine.cpp
@@ -1,12 +1,13 @@
 #include "ScriptEngine.h"
-#include <Coral/HostInstance.hpp>
-#include "../Log.h"
+#include "ScriptInterface.h"
+#include "../Core/Entity.h"
 
 namespace Razor
 {
 	Coral::HostInstance ScriptEngine::CoralInstance = Coral::HostInstance();
 	Coral::AssemblyLoadContext ScriptEngine::Context = Coral::AssemblyLoadContext();
 	bool ScriptEngine::ScriptEngineInitialised = false;
+	Scope<ScriptEngineData> ScriptEngine::s_Data = CreateScope<ScriptEngineData>();
 
 	void CoralMessageCallback(std::string_view message, Coral::MessageLevel level)
 	{
@@ -38,29 +39,54 @@ namespace Razor
 		ScriptEngineInitialised = true;
 	}
 
-	Razor::Ref<Coral::ManagedAssembly> ScriptEngine::LoadAssembly(const std::string& AssemblyPath)
+	Coral::ManagedAssembly& ScriptEngine::LoadAssembly(const std::string& AssemblyPath)
 	{
 		if (!ScriptEngineInitialised)
 		{
 			RZ_CORE_ERROR("ScriptEngine: -> Attempting to load assembly before scriptengine is initialised");
-			return nullptr;
+			Coral::ManagedAssembly emptyAssembly;
+			return emptyAssembly;
 		}
-		return Razor::Ref<Coral::ManagedAssembly>(&Context.LoadAssembly(AssemblyPath));
-		//Coral::ManagedAssembly loadedAssembly = Context.LoadAssembly(AssemblyPath);
-		/*if (loadedAssembly.GetLoadStatus() != Coral::AssemblyLoadStatus::Success)
+		Coral::ManagedAssembly& assembly = Context.LoadAssembly(AssemblyPath);
+
+		for (Coral::Type* Type : assembly.GetTypes())
 		{
-			RZ_CORE_ERROR("ScriptEngine: -> Failed to load assembly at path: {0}", AssemblyPath);
-			return nullptr;
+			std::string Name = Type->GetFullName();
+			const char* splitter = ".";
+			Ref<ScriptClass> Class = CreateRef<ScriptClass>(std::strtok(&Name[0], splitter), Type->GetFullName());
+			s_Data->ScriptClasses[Type->GetFullName()] = Class;
+
+			for (Coral::FieldInfo& Field : Type->GetFields())
+			{
+				Class->m_Fields[Field.GetName()] = { Field.GetType(), Field.GetName(), Field };
+			}
 		}
-		else
-		{
-			return Razor::Ref<Coral::ManagedAssembly>(&loadedAssembly);
-		}*/
+
+		return assembly;
 	}
 
 	void ScriptEngine::Shutdown()
 	{
 		CoralInstance.UnloadAssemblyLoadContext(Context);
 		CoralInstance.Shutdown();
+	}
+
+	Ref<ScriptClass> ScriptEngine::GetEntityClass(const std::string& name)
+	{
+		if (s_Data->ScriptClasses.find(name) == s_Data->ScriptClasses.end())
+			return nullptr;
+
+		return s_Data->ScriptClasses.at(name);
+	}
+
+	ScriptFieldMap& ScriptEngine::GetScriptFieldMap(Entity entity)
+	{
+		return s_Data->EntityScriptFields[static_cast<uint32_t>(entity.EntityHandle)];
+	}
+
+	ScriptClass::ScriptClass(const std::string& classNamespace, const std::string& className, bool isCore)
+		: m_ClassNamespace(classNamespace), m_ClassName(className)
+	{
+		
 	}
 }

--- a/Razor/src/Razor/Scripting/ScriptEngine.h
+++ b/Razor/src/Razor/Scripting/ScriptEngine.h
@@ -1,27 +1,191 @@
 #pragma once
 #include "../Core.h"
-
-namespace Coral
-{
-	class ManagedAssembly;
-	class HostInstance;
-	class AssemblyLoadContext;
-}
+#include <map>
+#include <unordered_map>
+#include <filesystem>
+#include "../Log.h"
+#include <Coral/HostInstance.hpp>
 
 namespace Razor
 {
+	class Scene;
+	struct ScriptAssembly;
+	class Entity;
+
+	enum class ScriptFieldType
+	{
+		None = 0,
+		Float, Double,
+		Bool, Char, Byte, Short, Int, Long,
+		UByte, UShort, UInt, ULong,
+		Vector2, Vector3, Vector4,
+		Entity,
+	};
+
+	struct ScriptField
+	{
+		Coral::Type Type;
+		Coral::String Name;
+		Coral::FieldInfo ClassField;
+
+		ScriptFieldType GetType() const
+		{
+			Coral::ManagedType managedType = Type.GetManagedType();
+			switch (managedType)
+			{
+			case Coral::ManagedType::Float:		return ScriptFieldType::Float;
+			case Coral::ManagedType::Double:	return ScriptFieldType::Double;
+			case Coral::ManagedType::Bool:		return ScriptFieldType::Bool;
+			case Coral::ManagedType::Byte:		return ScriptFieldType::Char;
+			case Coral::ManagedType::UInt:		return ScriptFieldType::UInt;
+			case Coral::ManagedType::Int:		return ScriptFieldType::Int;
+			default:
+				return ScriptFieldType::None;
+			}
+		}
+	};
+
+	// ScriptField + data storage
+	struct ScriptFieldInstance
+	{
+		ScriptField Field;
+
+		ScriptFieldInstance()
+		{
+			memset(m_Buffer, 0, sizeof(m_Buffer));
+		}
+
+		template<typename T>
+		T GetValue()
+		{
+			static_assert(sizeof(T) <= 16, "Type too large!");
+			return *(T*)m_Buffer;
+		}
+
+		template<typename T>
+		void SetValue(T value)
+		{
+			static_assert(sizeof(T) <= 16, "Type too large!");
+			memcpy(m_Buffer, &value, sizeof(T));
+		}
+	private:
+		uint8_t m_Buffer[16];
+	};
+
+	using ScriptFieldMap = std::unordered_map<std::string, ScriptFieldInstance>;
+
+	class ScriptClass
+	{
+	public:
+		ScriptClass() = default;
+		ScriptClass(const std::string& classNamespace, const std::string& className, bool isCore = false);
+
+		const std::map<std::string, ScriptField>& GetFields() const { return m_Fields; }
+	private:
+		std::string m_ClassNamespace;
+		std::string m_ClassName;
+
+		std::map<std::string, ScriptField> m_Fields;
+
+		friend class ScriptEngine;
+	};
+
+	struct ScriptEngineData
+	{
+		Scope<ScriptAssembly> BridgeAssembly = nullptr;
+		Scope<ScriptAssembly> GameAssembly = nullptr;
+
+		std::filesystem::path CoreAssemblyFilepath;
+		std::filesystem::path AppAssemblyFilepath;
+
+		ScriptClass EntityClass;
+
+		std::unordered_map<std::string, Ref<ScriptClass>> ScriptClasses;
+		//std::unordered_map<UUID, Ref<ScriptInstance>> EntityInstances;
+		std::unordered_map<uint32_t, ScriptFieldMap> EntityScriptFields;
+
+		//Scope<filewatch::FileWatch<std::string>> AppAssemblyFileWatcher;
+		//bool AssemblyReloadPending = false;
+
+		// Runtime
+
+		Scene* SceneContext = nullptr;
+	};
+
 	class RAZOR_API ScriptEngine
 	{
 
 	public:
 		static void Init();
 		static void Shutdown();
-		static Razor::Ref<Coral::ManagedAssembly> LoadAssembly(const std::string& AssemblyPath);
+		static Coral::ManagedAssembly& LoadAssembly(const std::string& AssemblyPath);
+		static Ref<ScriptClass> GetEntityClass(const std::string& name);
+		static ScriptFieldMap& GetScriptFieldMap(Entity entity);
 
 	private:
 		static Coral::HostInstance CoralInstance;
 		static Coral::AssemblyLoadContext Context;
 		static bool ScriptEngineInitialised;
+		static Scope<ScriptEngineData> s_Data;
 	};
+
+
+	namespace Utils {
+
+		inline const char* ScriptFieldTypeToString(ScriptFieldType fieldType)
+		{
+			switch (fieldType)
+			{
+			case ScriptFieldType::None:    return "None";
+			case ScriptFieldType::Float:   return "Float";
+			case ScriptFieldType::Double:  return "Double";
+			case ScriptFieldType::Bool:    return "Bool";
+			case ScriptFieldType::Char:    return "Char";
+			case ScriptFieldType::Byte:    return "Byte";
+			case ScriptFieldType::Short:   return "Short";
+			case ScriptFieldType::Int:     return "Int";
+			case ScriptFieldType::Long:    return "Long";
+			case ScriptFieldType::UByte:   return "UByte";
+			case ScriptFieldType::UShort:  return "UShort";
+			case ScriptFieldType::UInt:    return "UInt";
+			case ScriptFieldType::ULong:   return "ULong";
+			case ScriptFieldType::Vector2: return "Vector2";
+			case ScriptFieldType::Vector3: return "Vector3";
+			case ScriptFieldType::Vector4: return "Vector4";
+			case ScriptFieldType::Entity:  return "Entity";
+			}
+			RZ_CORE_ERROR("Unknown ScriptFieldType");
+			return "None";
+		}
+
+		inline ScriptFieldType ScriptFieldTypeFromString(std::string_view fieldType)
+		{
+			if (fieldType == "None")    return ScriptFieldType::None;
+			if (fieldType == "Float")   return ScriptFieldType::Float;
+			if (fieldType == "Double")  return ScriptFieldType::Double;
+			if (fieldType == "Bool")    return ScriptFieldType::Bool;
+			if (fieldType == "Char")    return ScriptFieldType::Char;
+			if (fieldType == "Byte")    return ScriptFieldType::Byte;
+			if (fieldType == "Short")   return ScriptFieldType::Short;
+			if (fieldType == "Int")     return ScriptFieldType::Int;
+			if (fieldType == "Long")    return ScriptFieldType::Long;
+			if (fieldType == "UByte")   return ScriptFieldType::UByte;
+			if (fieldType == "UShort")  return ScriptFieldType::UShort;
+			if (fieldType == "UInt")    return ScriptFieldType::UInt;
+			if (fieldType == "ULong")   return ScriptFieldType::ULong;
+			if (fieldType == "Vector2") return ScriptFieldType::Vector2;
+			if (fieldType == "Vector3") return ScriptFieldType::Vector3;
+			if (fieldType == "Vector4") return ScriptFieldType::Vector4;
+			if (fieldType == "Entity")  return ScriptFieldType::Entity;
+
+			RZ_CORE_ERROR("Unknown ScriptFieldType");
+			return ScriptFieldType::None;
+		}
+
+
+
+	}
 }
+
+
 

--- a/Razor/src/Razor/Scripting/ScriptGlue.cpp
+++ b/Razor/src/Razor/Scripting/ScriptGlue.cpp
@@ -15,7 +15,7 @@ namespace Razor
 		RZ_INFO(message);
 	}
 	
-	void ScriptGlue::RegisterFunctions(Razor::Ref<Coral::ManagedAssembly> Assembly)
+	void ScriptGlue::RegisterFunctions(Ref<Coral::ManagedAssembly> Assembly)
 	{
 		Assembly->AddInternalCall("Razor.InternalCalls", "Entity_HasComponent", (void*)Entity_HasComponent);
 		Assembly->AddInternalCall("Razor.InternalCalls", "Print_Message", (void*)Print_Message);

--- a/Razor/src/Razor/Scripting/ScriptGlue.h
+++ b/Razor/src/Razor/Scripting/ScriptGlue.h
@@ -14,7 +14,7 @@ namespace Razor
 	{
 	public:
 		static void RegisterComponents();
-		static void RegisterFunctions(Razor::Ref<Coral::ManagedAssembly> Assembly);
+		static void RegisterFunctions(Ref<Coral::ManagedAssembly> Assembly);
 
 
 	};

--- a/Razor/src/Razor/Scripting/ScriptInterface.cpp
+++ b/Razor/src/Razor/Scripting/ScriptInterface.cpp
@@ -13,17 +13,21 @@ namespace Razor
 
 	ScriptAssembly ScriptInterface::LoadAssembly(std::string assemblyPath, bool isBridgeAssembly)
 	{
-		Razor::Ref<Coral::ManagedAssembly> Assembly = ScriptEngine::LoadAssembly(assemblyPath);
-		if (Assembly == nullptr)
+		AssemblyPool.push_back(CreateRef<Coral::ManagedAssembly>(ScriptEngine::LoadAssembly(assemblyPath)));
+
+		Ref<Coral::ManagedAssembly> Assembly = AssemblyPool.back();
+		if (Assembly->GetLoadStatus() == Coral::AssemblyLoadStatus::UnknownError)
 		{
 			RZ_CORE_ERROR("ScriptInterface: -> Failed to load assembly at path: {0}", assemblyPath);
-			return ScriptAssembly { -1 };
+			return ScriptAssembly{ -1 };
 		}
+
 		if (isBridgeAssembly)
 		{
 			ScriptGlue::RegisterFunctions(Assembly);
 		}
-		AssemblyPool.push_back(Assembly);
+		// This is a nightmare how do we fix it hahaha
+		;
 		return ScriptAssembly { static_cast<int>(AssemblyPool.size()) - 1};
 	}
 
@@ -33,7 +37,7 @@ namespace Razor
 		{
 			return ScriptType();
 		}
-		Razor::Ref<Coral::ManagedAssembly> searchingAssembly = AssemblyPool[assembly.assemblyIndex];
+		Ref<Coral::ManagedAssembly> searchingAssembly = AssemblyPool[assembly.assemblyIndex];
 
 		Coral::Type& returnedType = searchingAssembly->GetType(typeName);
 
@@ -96,7 +100,7 @@ namespace Razor
 
 	ScriptObject ScriptInterface::CreateInstance(ScriptType type)
 	{
-		Razor::Ref<Coral::ManagedAssembly> instanceAssembly = AssemblyPool[type.assembly.assemblyIndex];
+		Ref<Coral::ManagedAssembly> instanceAssembly = AssemblyPool[type.assembly.assemblyIndex];
 		Coral::Type& instanceType = instanceAssembly->GetType(type.fullName);
 		ObjectPool.push_back(std::move(Razor::CreateRef<Coral::ManagedObject>(instanceType.CreateInstance())));
 		return ScriptObject {static_cast<int>(ObjectPool.size()) - 1, type};

--- a/Razor/src/Razor/Scripting/ScriptInterface.h
+++ b/Razor/src/Razor/Scripting/ScriptInterface.h
@@ -53,7 +53,7 @@ namespace Razor
 	private:
 		std::vector<Razor::Ref<Coral::ManagedObject>> ObjectPool;
 		std::unordered_map<int32_t, ScriptType> TypePool;
-		std::vector<Razor::Ref<Coral::ManagedAssembly>> AssemblyPool;
+		std::vector<Ref<Coral::ManagedAssembly>> AssemblyPool;
 	};
 }
 


### PR DESCRIPTION
### Description
Reworked engine calls to allow for an easier solution for starting and stopping runtime.

### Changes

- `Engine::Render` call now takes a targetId to render to
- Removed calls to `Step` and `RunSystems` inside `Edge::Run`
- Added Menu to Menu Bar to allow starting and stopping of Runtime
- Moved Project load logic to `Engine`
- `EditorStorage` now stores CurrentProjectPath rather than CurrentProject
- `OpenProjectPopupWindow` now just sets the path to the project selected
- Added `ScriptComponent`
- `Engine::RunSystems` now calls `Scene::RunSystems`
- Added `RuntimeStart`, `RunRuntime` & `RuntimeStop` to `Engine`
- `YamlWrapper` can now deal with `Vector2`, `Char`, `int32` & `float`
- Added `RunSystems` and `CreateSystemObject` to `Scene`
- Can now serialize and deserialize ScriptComponents partially still missing `ScriptFieldMap` populating logic in `ScriptEngine`
- On loading assembly we will now gather all Classes and associated fields and store in `s_Data::ScriptClasses`
