### PR TITLE
Feat - Edge Create Entity

### DIFF
--- a/Edge/src/EdgeApp.cpp
+++ b/Edge/src/EdgeApp.cpp
@@ -226,6 +226,10 @@ void Edge::CreateDockspace(const std::string& Title)
 			{
 				CurrentPopup = new EdgeEditor::OpenProjectPopupWindow(Storage);
 			}
+			if (Razor::RazorImGui::MenuItem("Save Project"))
+			{
+				Razor::Engine::Get().SaveProject();
+			}
 			Razor::RazorImGui::EndMenu();
 		}
 		if (Razor::RazorImGui::BeginMenu("Run"))

--- a/Edge/src/SceneView.cpp
+++ b/Edge/src/SceneView.cpp
@@ -24,6 +24,11 @@ namespace EdgeEditor
 
 		Razor::Ref<Razor::Scene> CurrentScene = Engine.CurrentScene;
 
+		if(Razor::RazorImGui::Button("Add Entity"))
+		{
+			CurrentScene->CreateEntity();
+		}
+
 		if (Razor::RazorImGui::TreeNode("Entities"))
 		{
 			// Need wrapper for the view type not lovely to have

--- a/Razor/src/Razor/Engine.cpp
+++ b/Razor/src/Razor/Engine.cpp
@@ -200,6 +200,17 @@ namespace Razor
 		return *ScriptInterface;
 	}
 
+	void Engine::SaveProject()
+	{
+		if (LoadedProject == nullptr)
+		{
+			RZ_CORE_ERROR("Attempting to save project when no project is loaded");
+			return;
+		}
+
+		ProjectSerializer::Serialize(LoadedProject->m_ProjectPath, LoadedProject);
+	}
+
 	void Engine::LoadProject(const std::string& ProjectPath)
 	{
 		if (ProjectPath.empty())
@@ -216,17 +227,17 @@ namespace Razor
 		const std::string Path = "../Sandbox";
 
 		ProjectSerializer::Deserialize(ProjectPath, LoadedProject);
-		RZ_CORE_INFO("Loading up project: {0}", LoadedProject->ProjectName);
+		RZ_CORE_INFO("Loading up project: {0}", LoadedProject->m_ProjectName);
 		// TODO move assembly holding into ScriptEngine
-		BridgeAssembly = CreateScope<ScriptAssembly>(ScriptInterface->LoadAssembly(Path + "/" + LoadedProject->DllDirectory + "/" + "Razor-ScriptBridge.dll", true));
-		GameAssembly = CreateScope<ScriptAssembly>(ScriptInterface->LoadAssembly(Path + "/" + LoadedProject->DllDirectory + "/" + LoadedProject->ProjectName + ".dll", false));
+		BridgeAssembly = CreateScope<ScriptAssembly>(ScriptInterface->LoadAssembly(Path + "/" + LoadedProject->m_DllDirectory + "/" + "Razor-ScriptBridge.dll", true));
+		GameAssembly = CreateScope<ScriptAssembly>(ScriptInterface->LoadAssembly(Path + "/" + LoadedProject->m_DllDirectory + "/" + LoadedProject->m_ProjectName + ".dll", false));
 
 		// Load main scene
-		Ref<Scene> MainScene = CreateRef<Scene>(Path + LoadedProject->MainScenePath);
+		Ref<Scene> MainScene = CreateRef<Scene>(Path + LoadedProject->m_MainScenePath);
 		if (SceneSerializer::Deserialize(MainScene) == false)
 		{
-			LoadedProject->MainScenePath = "/assets/scenes/Main.rzscn";
-			MainScene = CreateRef<Scene>(LoadedProject->MainScenePath);
+			LoadedProject->m_MainScenePath = "/assets/scenes/Main.rzscn";
+			MainScene = CreateRef<Scene>(LoadedProject->m_MainScenePath);
 			SceneSerializer::Serialize(MainScene);
 			ProjectSerializer::Serialize("../", LoadedProject);
 		}

--- a/Razor/src/Razor/Engine.h
+++ b/Razor/src/Razor/Engine.h
@@ -154,6 +154,7 @@ namespace Razor
 
 		ScriptInterface& GetScriptInterface();
 
+		void SaveProject();
 		void LoadProject(const std::string& ProjectPath);
 
 		void RuntimeStart();

--- a/Razor/src/Razor/IO/File/ProjectSerializer.cpp
+++ b/Razor/src/Razor/IO/File/ProjectSerializer.cpp
@@ -17,45 +17,44 @@ namespace Razor
 			return;
 		}
 
-		if (Project->ProjectName == "")
+		if (Project->m_ProjectName == "")
 		{
 			RZ_CORE_ERROR("ProjectSerializer::Serialize Error: Project Name cannot be an empty string");
 			return;
 		}
 
-		const std::string ProjectFolderPath = Path + "/" + Project->ProjectName;
-		std::string AssetFolderPath = Project->AssetDirectory;
-		std::string DllFolderPath = Project->DllDirectory;
-		if (Project->AssetDirectory.empty())
+		std::string AssetFolderPath = Project->m_AssetDirectory;
+		std::string DllFolderPath = Project->m_DllDirectory;
+		if (Project->m_AssetDirectory.empty())
 		{
-			AssetFolderPath = ProjectFolderPath + "/" + "assets";
+			AssetFolderPath = Path + "/" + "assets";
 			std::filesystem::create_directory(AssetFolderPath);
 		}
-		if (Project->DllDirectory.empty())
+		if (Project->m_DllDirectory.empty())
 		{
-			DllFolderPath = ProjectFolderPath + "/" + "assembly";
+			DllFolderPath = Path + "/" + "assembly";
 			std::filesystem::create_directory(DllFolderPath);
 		}
 
-		Project->AssetDirectory = AssetFolderPath;
-		Project->DllDirectory = DllFolderPath;
+		Project->m_AssetDirectory = AssetFolderPath;
+		Project->m_DllDirectory = DllFolderPath;
 
 		YamlEmitter* Out =  yaml_emitter_new();
 		yaml_emitter_begin_map(Out);
 		yaml_emitter_key(Out, "ProjectName");
-		yaml_emitter_value_string(Out, Project->ProjectName.c_str());
+		yaml_emitter_value_string(Out, Project->m_ProjectName.c_str());
 		yaml_emitter_key(Out, "AssetDirectory");
-		yaml_emitter_value_string(Out, Project->AssetDirectory.c_str());
+		yaml_emitter_value_string(Out, Project->m_AssetDirectory.c_str());
 		yaml_emitter_key(Out, "DllDirectory");
-		yaml_emitter_value_string(Out, Project->DllDirectory.c_str());
+		yaml_emitter_value_string(Out, Project->m_DllDirectory.c_str());
 		yaml_emitter_key(Out, "MainScenePath");
-		yaml_emitter_value_string(Out, Project->MainScenePath.c_str());
+		yaml_emitter_value_string(Out, Project->m_MainScenePath.c_str());
 		yaml_emitter_end_map(Out);
 
 
-		std::filesystem::create_directory(ProjectFolderPath);
+		std::filesystem::create_directory(Path);
 
-		const std::string PathPlusExt = ProjectFolderPath + "/" + Project->ProjectName + ".proj";
+		const std::string PathPlusExt = Path + "/" + Project->m_ProjectName + ".proj";
 
 		std::ofstream FOut(PathPlusExt.c_str());
 		const char* ErrorMsg = new char(' ');
@@ -86,10 +85,11 @@ namespace Razor
 			return;
 		}
 
-		OutProject->ProjectName = Razor::yaml_as_string(Razor::yaml_get_child(Data, "ProjectName"));
-		OutProject->AssetDirectory = Razor::yaml_as_string(Razor::yaml_get_child(Data, "AssetDirectory"));
-		OutProject->DllDirectory = Razor::yaml_as_string(Razor::yaml_get_child(Data, "DllDirectory"));
-		OutProject->MainScenePath = Razor::yaml_as_string(Razor::yaml_get_child(Data, "MainScenePath"));
+		OutProject->m_ProjectName = Razor::yaml_as_string(Razor::yaml_get_child(Data, "ProjectName"));
+		OutProject->m_AssetDirectory = Razor::yaml_as_string(Razor::yaml_get_child(Data, "AssetDirectory"));
+		OutProject->m_DllDirectory = Razor::yaml_as_string(Razor::yaml_get_child(Data, "DllDirectory"));
+		OutProject->m_MainScenePath = Razor::yaml_as_string(Razor::yaml_get_child(Data, "MainScenePath"));
+		OutProject->m_ProjectPath = Path.substr(0, Path.find_last_of("/\\"));
 	}
 
 }

--- a/Razor/src/Razor/Scene/Project.h
+++ b/Razor/src/Razor/Scene/Project.h
@@ -9,15 +9,16 @@ namespace Razor
 	*/
 	struct Project
 	{
-		std::string ProjectName; /** Name of the project */
-		std::string AssetDirectory; /** Directory containing all the asset files */
-		std::string DllDirectory; /** Directory containing the scripting DLL */
-		std::string MainScenePath; /** Path to the main scene (we will open this on load up)*/
+		std::string m_ProjectName; /** Name of the project */
+		std::string m_AssetDirectory; /** Directory containing all the asset files */
+		std::string m_DllDirectory; /** Directory containing the scripting DLL */
+		std::string m_MainScenePath; /** Path to the main scene (we will open this on load up)*/
+		std::string m_ProjectPath; /** Path to the project dir itself */
 
 		/**
 		* Default constructor for Project class
 		*/
-		Project() : ProjectName(""), AssetDirectory(""), DllDirectory("")
+		Project() : m_ProjectName(""), m_AssetDirectory(""), m_DllDirectory(""), m_MainScenePath(""), m_ProjectPath("")
 		{
 
 		}
@@ -29,8 +30,8 @@ namespace Razor
 		* @param AssetDirectory - directory containing all the asset files
 		* @param DllDirectory - directory containing the scripting DLL
 		*/
-		Project(std::string ProjectName, std::string AssetDirectory, std::string DllDirectory)
-			: ProjectName(ProjectName), AssetDirectory(AssetDirectory), DllDirectory(DllDirectory)
+		Project(const std::string& ProjectName, const std::string& AssetDirectory, const std::string& DllDirectory, const std::string& ProjectPath)
+			: m_ProjectName(ProjectName), m_AssetDirectory(AssetDirectory), m_DllDirectory(DllDirectory), m_ProjectPath(ProjectPath)
 		{
 
 		}

--- a/Razor/src/Razor/Scene/Scene.cpp
+++ b/Razor/src/Razor/Scene/Scene.cpp
@@ -21,6 +21,7 @@ namespace Razor
 	{
 		auto entityHandle = registry.create();
 		Ref<Entity> ent = CreateRef<Entity>(entityHandle, this);
+		ent->AddComponent<Transform>();
 		return ent;
 	}
 	

--- a/Razor/src/Razor/Scene/SceneSerializer.cpp
+++ b/Razor/src/Razor/Scene/SceneSerializer.cpp
@@ -196,7 +196,7 @@ namespace Razor
 		{
 			for (auto EntityNode : yaml_get_children(Data, "Entities"))
 			{
-				
+				DeserializeEntity(EntityNode, OutScene);
 			}
 		}
 		return true;
@@ -206,13 +206,13 @@ namespace Razor
 	{
 		Ref<Entity> DeserializedEntity = OutScene->CreateEntity();
 		auto TransformComponent = yaml_get_child(EntityNode, "Transform");
+		/* This is a one-off case as all entities are created with transform components so we don't need to add one just pass data */
 		if (TransformComponent)
 		{
-			glm::vec3 Position = ToGVec3(yaml_as_vec3(yaml_get_child(TransformComponent, "Position")));
-			glm::vec3 Rotation = ToGVec3(yaml_as_vec3(yaml_get_child(TransformComponent, "Rotation")));
-			glm::vec3 Scale = ToGVec3(yaml_as_vec3(yaml_get_child(TransformComponent, "Scale")));
-			Transform EntityTransform = { Position, Scale, Rotation };
-			DeserializedEntity->AddComponent<Transform>(EntityTransform);
+			Transform& comp = DeserializedEntity->GetComponent<Transform>();
+			comp.Position = ToGVec3(yaml_as_vec3(yaml_get_child(TransformComponent, "Position")));
+			comp.Rotation = ToGVec3(yaml_as_vec3(yaml_get_child(TransformComponent, "Rotation")));
+			comp.Scale = ToGVec3(yaml_as_vec3(yaml_get_child(TransformComponent, "Scale")));
 		}
 		auto ScriptComponent = yaml_get_child(EntityNode, "ScriptComponent");
 		if (ScriptComponent)

--- a/Sandbox/assets/scenes/Main.rzscn
+++ b/Sandbox/assets/scenes/Main.rzscn
@@ -1,3 +1,12 @@
 Scene: Untitled
 Entities:
-  []
+  - Entity: 1
+    Transform:
+      Position: [10, 0, 0]
+      Rotation: [0, 0, 0]
+      Scale: [0, 0, 0]
+  - Entity: 0
+    Transform:
+      Position: [0, 10, 0]
+      Rotation: [0, 0, 0]
+      Scale: [0, 0, 0]


### PR DESCRIPTION
### Description
This change is to allow the user to create entities in a scene from within the Scene View window, these entities are created blank apart from a Transform component.

### Changes
- New MenuItem in File menu to Save Project
- New button in SceneView to Create Entity
- Added SaveProject func to Engine
- Renamed Project member vars to new code style
- Added new ProjectPath var to Project to hold directory project file is located in
- CreateEntity func now adds a Transform component by default
- DeserializeEntity in SceneSerializer now copies data in Transform node to existing Transform component on Entity rather than create a new one 