### PR TITLE
feature [Editor]: Open project in-editor file explorer

### DIFF
--- a/Edge/src/Gui/OpenProjectPopupWindow.cpp
+++ b/Edge/src/Gui/OpenProjectPopupWindow.cpp
@@ -1,11 +1,12 @@
 #include "OpenProjectPopupWindow.h"
 #include "../EditorStorage.h"
 #include <filesystem>
-#include <sys/stat.h>
 
 
 namespace EdgeEditor
 {
+	static constexpr const char* POPUP_NAME = "Open Project Window";
+
 	static std::string NormalizePath(const std::string& path)
 	{
 		return static_cast<std::string>(Razor::FilePath(path));
@@ -29,7 +30,7 @@ namespace EdgeEditor
 		{
 			Open();
 		}
-		if (Razor::RazorImGui::BeginPopupModal("Open Project Window", nullptr))
+		if (Razor::RazorImGui::BeginPopupModal(POPUP_NAME, nullptr))
 		{
 			Razor::RazorImGui::BeginTable("FileTable", 4);
 			std::vector<Razor::FilePath> files = GrabFiles(_mSearchStack.top());
@@ -48,7 +49,6 @@ namespace EdgeEditor
 			if (bSelected)
 			{
 				Close();
-				bIsOpen = false;
 			}
 			else
 			{
@@ -58,20 +58,11 @@ namespace EdgeEditor
 					{
 						_mSearchStack.pop();
 					}
-					else
-					{
-						// Navigate above the starting root — compute parent directory
-						std::string parent = NormalizePath(
-							std::filesystem::path(_mSearchStack.top()).parent_path().string());
-						if (!parent.empty() && parent != _mSearchStack.top())
-							_mSearchStack.top() = parent;
-					}
 				}
 				Razor::RazorImGui::SameLine();
 				if (Razor::RazorImGui::Button("Cancel"))
 				{
 					Close();
-					bIsOpen = false;
 				}
 			}
 
@@ -82,13 +73,13 @@ namespace EdgeEditor
 
 	void OpenProjectPopupWindow::Open()
 	{
-		bIsOpen = true;
-		Razor::RazorImGui::OpenPopup("Open Project Window");
 		if (Storage == nullptr)
 		{
-			RZ_ERROR("OpenProjectPopupWindow Error: Editor Storage ref not provided closing popup window");
-			Close();
+			RZ_ERROR("OpenProjectPopupWindow Error: Editor Storage ref not provided, cannot open popup");
+			return;
 		}
+		bIsOpen = true;
+		Razor::RazorImGui::OpenPopup(POPUP_NAME);
 	}
 
 	void OpenProjectPopupWindow::Close()
@@ -101,24 +92,22 @@ namespace EdgeEditor
 	{
 		std::vector<Razor::FilePath> fileNames;
 
-		struct stat sb;
-
-		for (const std::filesystem::directory_entry& DirectoryEntry : std::filesystem::directory_iterator(Path))
+		try
 		{
-			std::filesystem::path filePath = DirectoryEntry.path();
-			std::string fileName = filePath.string();
-			Razor::FilePath path(fileName);
-
-			bool bIsDirectory = false;
-			if (stat(static_cast<std::string>(path).c_str(), &sb) == 0 && (sb.st_mode & S_IFDIR))
+			for (const std::filesystem::directory_entry& DirectoryEntry : std::filesystem::directory_iterator(Path))
 			{
-				bIsDirectory = true;
-			}
+				const std::filesystem::path& filePath = DirectoryEntry.path();
+				bool bIsDirectory = DirectoryEntry.is_directory();
 
-			if (bIsDirectory || fileName.size() >= 5 && fileName.substr(fileName.size() - 5) == ".proj")
-			{
-				fileNames.push_back({ path, bIsDirectory });
+				if (bIsDirectory || (filePath.extension() == ".proj"))
+				{
+					fileNames.push_back({ Razor::FilePath(filePath.string()), bIsDirectory });
+				}
 			}
+		}
+		catch (const std::filesystem::filesystem_error& e)
+		{
+			RZ_ERROR("OpenProjectPopupWindow: Failed to iterate directory '{0}': {1}", Path, e.what());
 		}
 
 		return fileNames;
@@ -129,17 +118,20 @@ namespace EdgeEditor
 		Razor::FilePath labelPath = file.RemoveFromPath(Razor::FilePath(_mSearchStack.top()));
 		std::string label = static_cast<std::string>(labelPath);
 
+		if (label.empty())
+			return false;
+
 		// Use Button (not ImageButton) so each entry gets a unique ImGui ID derived from its name.
 		// ImageButton uses the texture pointer as the ID; with nullptr all buttons share ID 0.
 		if (Razor::RazorImGui::Button(label.c_str()))
 		{
 			if (!file.IsDir())
 			{
-				std::string fullPath = static_cast<std::string>(file);
+				std::filesystem::path fsPath(static_cast<std::string>(file));
 				// strip ".proj" — ProjectSerializer::Deserialize appends it
-				if (fullPath.size() >= 5)
-					fullPath = fullPath.substr(0, fullPath.size() - 5);
-				Storage->SetProjectPath(fullPath);
+				if (fsPath.extension() == ".proj")
+					fsPath.replace_extension("");
+				Storage->SetProjectPath(fsPath.string());
 				return true;
 			}
 			else

--- a/Edge/src/Gui/OpenProjectPopupWindow.cpp
+++ b/Edge/src/Gui/OpenProjectPopupWindow.cpp
@@ -1,46 +1,152 @@
 #include "OpenProjectPopupWindow.h"
 #include "../EditorStorage.h"
+#include <filesystem>
+#include <sys/stat.h>
 
 
 namespace EdgeEditor
 {
+	static std::string NormalizePath(const std::string& path)
+	{
+		return static_cast<std::string>(Razor::FilePath(path));
+	}
+
+	OpenProjectPopupWindow::OpenProjectPopupWindow()
+		: bIsOpen(false), Storage(nullptr)
+	{
+		_mSearchStack.push(NormalizePath(std::filesystem::current_path().string()));
+	}
+
+	OpenProjectPopupWindow::OpenProjectPopupWindow(Razor::Ref<EditorStorage> Storage)
+		: bIsOpen(false), Storage(Storage)
+	{
+		_mSearchStack.push(NormalizePath(std::filesystem::current_path().string()));
+	}
+
 	bool OpenProjectPopupWindow::Draw()
 	{
-		if (bIsOpen == false)
+		if (!bIsOpen)
 		{
 			Open();
 		}
-		if (Razor::RazorImGui::BeginPopupModal(WindowName.c_str(), nullptr))
+		if (Razor::RazorImGui::BeginPopupModal("Open Project Window", nullptr))
 		{
-			// TODO will create big old file explorer for now we just wanna have a button we click which directs us to the current Sandbox
-			if (Razor::RazorImGui::Button("Create"))
+			Razor::RazorImGui::BeginTable("FileTable", 4);
+			std::vector<Razor::FilePath> files = GrabFiles(_mSearchStack.top());
+			bool bSelected = false;
+			for (const Razor::FilePath& file : files)
 			{
-				Storage->SetProjectPath("/Sandbox/Sandbox");
-				Razor::RazorImGui::CloseCurrentPopup();
+				Razor::RazorImGui::TableNextColumn();
+				if (DrawFileGui(file))
+				{
+					bSelected = true;
+					break;
+				}
 			}
-			Razor::RazorImGui::SameLine();
-			if (Razor::RazorImGui::Button("Cancel"))
+			Razor::RazorImGui::EndTable();
+
+			if (bSelected)
 			{
 				Close();
 				bIsOpen = false;
 			}
+			else
+			{
+				if (Razor::RazorImGui::Button("Back"))
+				{
+					if (_mSearchStack.size() > 1)
+					{
+						_mSearchStack.pop();
+					}
+					else
+					{
+						// Navigate above the starting root — compute parent directory
+						std::string parent = NormalizePath(
+							std::filesystem::path(_mSearchStack.top()).parent_path().string());
+						if (!parent.empty() && parent != _mSearchStack.top())
+							_mSearchStack.top() = parent;
+					}
+				}
+				Razor::RazorImGui::SameLine();
+				if (Razor::RazorImGui::Button("Cancel"))
+				{
+					Close();
+					bIsOpen = false;
+				}
+			}
+
 			Razor::RazorImGui::EndPopup();
 		}
 		return bIsOpen;
 	}
+
 	void OpenProjectPopupWindow::Open()
 	{
 		bIsOpen = true;
-		Razor::RazorImGui::OpenPopup(WindowName.c_str());
+		Razor::RazorImGui::OpenPopup("Open Project Window");
 		if (Storage == nullptr)
 		{
 			RZ_ERROR("OpenProjectPopupWindow Error: Editor Storage ref not provided closing popup window");
 			Close();
 		}
 	}
+
 	void OpenProjectPopupWindow::Close()
 	{
 		bIsOpen = false;
 		Razor::RazorImGui::CloseCurrentPopup();
+	}
+
+	std::vector<Razor::FilePath> OpenProjectPopupWindow::GrabFiles(const std::string& Path)
+	{
+		std::vector<Razor::FilePath> fileNames;
+
+		struct stat sb;
+
+		for (const std::filesystem::directory_entry& DirectoryEntry : std::filesystem::directory_iterator(Path))
+		{
+			std::filesystem::path filePath = DirectoryEntry.path();
+			std::string fileName = filePath.string();
+			Razor::FilePath path(fileName);
+
+			bool bIsDirectory = false;
+			if (stat(static_cast<std::string>(path).c_str(), &sb) == 0 && (sb.st_mode & S_IFDIR))
+			{
+				bIsDirectory = true;
+			}
+
+			if (bIsDirectory || fileName.size() >= 5 && fileName.substr(fileName.size() - 5) == ".proj")
+			{
+				fileNames.push_back({ path, bIsDirectory });
+			}
+		}
+
+		return fileNames;
+	}
+
+	bool OpenProjectPopupWindow::DrawFileGui(const Razor::FilePath& file)
+	{
+		Razor::FilePath labelPath = file.RemoveFromPath(Razor::FilePath(_mSearchStack.top()));
+		std::string label = static_cast<std::string>(labelPath);
+
+		// Use Button (not ImageButton) so each entry gets a unique ImGui ID derived from its name.
+		// ImageButton uses the texture pointer as the ID; with nullptr all buttons share ID 0.
+		if (Razor::RazorImGui::Button(label.c_str()))
+		{
+			if (!file.IsDir())
+			{
+				std::string fullPath = static_cast<std::string>(file);
+				// strip ".proj" — ProjectSerializer::Deserialize appends it
+				if (fullPath.size() >= 5)
+					fullPath = fullPath.substr(0, fullPath.size() - 5);
+				Storage->SetProjectPath(fullPath);
+				return true;
+			}
+			else
+			{
+				_mSearchStack.push(static_cast<std::string>(file));
+			}
+		}
+		return false;
 	}
 }

--- a/Edge/src/Gui/OpenProjectPopupWindow.h
+++ b/Edge/src/Gui/OpenProjectPopupWindow.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "PopupWindow.h"
+#include <stack>
 #include <string>
+#include <vector>
 #include "Razor.h"
 
 
@@ -12,8 +14,8 @@ namespace EdgeEditor
 	class OpenProjectPopupWindow : public PopupWindow
 	{
 	public:
-		OpenProjectPopupWindow() : bIsOpen(false), WindowName("Open Project Window"), Storage(nullptr) {}
-		OpenProjectPopupWindow(Razor::Ref<EditorStorage> Storage) : bIsOpen(false), WindowName("Open Project Window"), Storage(Storage) {}
+		OpenProjectPopupWindow();
+		OpenProjectPopupWindow(Razor::Ref<EditorStorage> Storage);
 		/**
 		* Function to draw popup window function to be called when wishing to draw popup
 		*/
@@ -29,10 +31,11 @@ namespace EdgeEditor
 		*/
 		void Close() override;
 
+		std::vector<Razor::FilePath> GrabFiles(const std::string& Path);
+		bool DrawFileGui(const Razor::FilePath& file);
+
 		bool bIsOpen;
-		//TODO push this up to parent class
-		std::string WindowName;
 		Razor::Ref<EditorStorage> Storage;
+		std::stack<std::string> _mSearchStack;
 	};
 }
-

--- a/Razor-ScriptBridge/premake5.lua
+++ b/Razor-ScriptBridge/premake5.lua
@@ -2,7 +2,7 @@
 project "Razor-ScriptBridge"
         kind "SharedLib"
         language "C#"
-        dotnetframework "net8.0"
+        dotnetframework "net9.0"
         clr "UnSafe"
         
         targetdir("../Edge/Resources/Scripts")

--- a/Razor/src/Razor/Scripting/ScriptEngine.cpp
+++ b/Razor/src/Razor/Scripting/ScriptEngine.cpp
@@ -64,20 +64,22 @@ namespace Razor
 			const char* splitter = ".";
 			bool bIsSystem = false;
 			bool bIsComponent = false;
-			Coral::Type& baseType = Type->GetBaseType();
-			while (baseType) 
+			// Traverse base type chain via pointer — never assign through the reference,
+			// which would overwrite TypeCache entries and corrupt m_Id for later types.
+			Coral::Type* baseTypePtr = &Type->GetBaseType();
+			while (*baseTypePtr)
 			{
-				if (baseType.GetFullName() == "Razor.System") {
+				if (baseTypePtr->GetFullName() == "Razor.System") {
 					RZ_CORE_INFO("Found System Class: {0}",  std::string(Type->GetFullName()));
 					bIsSystem = true;
 					break;
 				}
-				if (baseType.GetFullName() == "Razor.Component") {
+				if (baseTypePtr->GetFullName() == "Razor.Component") {
 					RZ_CORE_INFO("Found Component Class: {0}", std::string(Type->GetFullName()));
 					bIsComponent = true;
 					break;
 				}
-				baseType = baseType.GetBaseType();
+				baseTypePtr = &baseTypePtr->GetBaseType();
 			}
 
 			Ref<ScriptClass> Class = CreateRef<ScriptClass>(std::strtok(&Name[0], splitter), Type->GetFullName(), bIsSystem, bIsComponent);

--- a/Razor/src/Razor/Scripting/ScriptInterface.cpp
+++ b/Razor/src/Razor/Scripting/ScriptInterface.cpp
@@ -3,6 +3,7 @@
 #include "ScriptGlue.h"
 #include "../Log.h"
 #include <Coral/HostInstance.hpp>
+#include <filesystem>
 
 namespace Razor
 {
@@ -13,12 +14,15 @@ namespace Razor
 
 	ScriptAssembly ScriptInterface::LoadAssembly(std::string assemblyPath, bool isBridgeAssembly)
 	{
-		AssemblyPool.push_back(CreateRef<Coral::ManagedAssembly>(ScriptEngine::LoadAssembly(assemblyPath)));
+		// Coral requires absolute paths; resolve relative paths against cwd
+		std::string absolutePath = std::filesystem::absolute(assemblyPath).string();
+		AssemblyPool.push_back(CreateRef<Coral::ManagedAssembly>(ScriptEngine::LoadAssembly(absolutePath)));
 
 		Ref<Coral::ManagedAssembly> Assembly = AssemblyPool.back();
-		if (Assembly->GetLoadStatus() == Coral::AssemblyLoadStatus::UnknownError)
+		if (Assembly->GetLoadStatus() != Coral::AssemblyLoadStatus::Success)
 		{
-			RZ_CORE_ERROR("ScriptInterface: -> Failed to load assembly at path: {0}", assemblyPath);
+			RZ_CORE_ERROR("ScriptInterface: -> Failed to load assembly at path: {0}", absolutePath);
+			AssemblyPool.pop_back();
 			return ScriptAssembly{ -1 };
 		}
 

--- a/Sandbox/Sandbox.proj
+++ b/Sandbox/Sandbox.proj
@@ -1,4 +1,4 @@
 ProjectName: Sandbox
 AssetDirectory: assets
-DllDirectory: Scripts/Binaries/net8.0
+DllDirectory: Scripts/Binaries/net9.0
 MainScenePath: /assets/scenes/Main.rzscn

--- a/Sandbox/Scripts/premake5.lua
+++ b/Sandbox/Scripts/premake5.lua
@@ -18,7 +18,7 @@ outputdir = "%{cfg.buildcfg}-%{cfg.system}-%{cfg.architecture}"
 project "Sandbox"
 	kind "SharedLib"
 	language "C#"
-	dotnetframework "net8.0"
+	dotnetframework "net9.0"
 
 	targetdir ("Binaries")
 	objdir ("Intermediates")

--- a/Sandbox/assets/scenes/Main.rzscn
+++ b/Sandbox/assets/scenes/Main.rzscn
@@ -2,7 +2,7 @@ Scene: Untitled
 Entities:
   - Entity: 2
     Transform:
-      Position: [1.6172402e-05, 8, -5.00001001]
+      Position: [4.22683188e-05, 0, -5]
       Rotation: [0, 0, 0]
       Scale: [0, 0, 0]
     Mesh:
@@ -10,9 +10,9 @@ Entities:
     ScriptComponent:
       []
     BoxBody:
-      UseGravity: true
-      IsStatic: false
-      MotionType: Dynamic
+      UseGravity: false
+      IsStatic: true
+      MotionType: Static
       Mass: 1
   - Entity: 1
     Transform:
@@ -28,7 +28,7 @@ Entities:
       []
   - Entity: 0
     Transform:
-      Position: [4.22683188e-05, 0, -5]
+      Position: [1.6172402e-05, 8, -5.00001001]
       Rotation: [0, 0, 0]
       Scale: [0, 0, 0]
     Mesh:
@@ -36,9 +36,9 @@ Entities:
     ScriptComponent:
       []
     BoxBody:
-      UseGravity: false
-      IsStatic: true
-      MotionType: Static
+      UseGravity: true
+      IsStatic: false
+      MotionType: Dynamic
       Mass: 1
 Systems:
   - Sandbox.PlayerMovement

--- a/agent-os/specs/2026-05-05-1500-open-project-file-browser/plan.md
+++ b/agent-os/specs/2026-05-05-1500-open-project-file-browser/plan.md
@@ -1,0 +1,33 @@
+# Open Project File Browser
+
+## Context
+
+The current `OpenProjectPopupWindow` is a placeholder: it shows a modal with hardcoded "Create" and "Cancel" buttons and a TODO comment noting that a file explorer is needed. The "Create" button writes a hardcoded path (`/Sandbox/Sandbox`) to `EditorStorage`. This means the editor cannot actually open arbitrary projects. The goal is to replace this placeholder with a functional ImGui file browser so the user can navigate the filesystem, find a `.proj` file, and load it.
+
+The browser must be cross-platform (no native OS dialogs), implemented entirely with `RazorImGui::` calls.
+
+---
+
+## Key Design Decisions
+
+- **Starting path:** `std::filesystem::current_path().string()` — repo root on both Windows and Linux when launched per CLAUDE.md
+- **Filter:** `GrabFiles()` returns only directories (for navigation) and `.proj` files (for selection)
+- **Selection:** Click a `.proj` file → strip last 5 chars (`.proj`) → `Storage->SetProjectPath(strippedPath)`
+- **Navigation:** Stack-based (`std::stack<std::string>`), Back guarded to size > 1, Cancel closes without loading
+- **Layout:** 4-column `RazorImGui::BeginTable` grid, `ImageButton(nullptr, {100,100})` + label per entry
+
+---
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `Edge/src/Gui/OpenProjectPopupWindow.h` | Added `_mSearchStack`, `GrabFiles()`, `DrawFileGui()` |
+| `Edge/src/Gui/OpenProjectPopupWindow.cpp` | Full rewrite — file browser replacing placeholder |
+
+---
+
+## Standards Applied
+
+- `editor/imgui-view-lifecycle` — `RazorImGui::` only, `BeginPopupModal` + `EndPopup`, `bIsOpen` boilerplate
+- `editor/editor-storage` — `Storage->SetProjectPath()` broadcasts delegate; no direct `Engine.LoadProject()` call

--- a/agent-os/specs/2026-05-05-1500-open-project-file-browser/references.md
+++ b/agent-os/specs/2026-05-05-1500-open-project-file-browser/references.md
@@ -1,0 +1,29 @@
+# References for Open Project File Browser
+
+## Similar Implementations
+
+### AssetPickerPopupWindow
+
+- **Location:** `Edge/src/Gui/AssetPickerPopupWindow.h` and `.cpp`
+- **Relevance:** Directly models the file browser we're building — same stack navigation, `GrabFiles()` with `std::filesystem::directory_iterator`, `DrawFileGui()` with `RazorImGui::ImageButton` in a 4-column table
+- **Key patterns to borrow:**
+  - `std::stack<std::string> _mSearchStack` for navigation history
+  - `GrabFiles(path)` using `std::filesystem::directory_iterator` + `stat()` for directory detection
+  - `DrawFileGui(file)` — directory click pushes to stack, file click sets selection and returns `true`
+  - `ImageButton(nullptr, {100,100})` + `Text(label)` per entry layout
+  - Back button guarded by `_mSearchStack.size() > 1`
+
+### OpenProjectPopupWindow (current placeholder)
+
+- **Location:** `Edge/src/Gui/OpenProjectPopupWindow.h` and `.cpp`
+- **Relevance:** The file being replaced — inherit its class shape, `PopupWindow` base, `Open()`/`Close()` pattern, and `EditorStorage` usage
+- **Key patterns to keep:**
+  - Constructor accepting `Razor::Ref<EditorStorage>`
+  - `Open()` calls `RazorImGui::OpenPopup(name)`
+  - `Close()` calls `RazorImGui::CloseCurrentPopup()`
+  - `Draw()` returns `bool bIsOpen`
+
+### ProjectSerializer
+
+- **Location:** `Razor/src/Razor/IO/File/ProjectSerializer.cpp:71`
+- **Relevance:** Confirms that `Deserialize(path)` appends `.proj` internally (`PathPlusExt = Path + ".proj"`), so the path we pass to `Storage->SetProjectPath()` must NOT include the `.proj` extension

--- a/agent-os/specs/2026-05-05-1500-open-project-file-browser/shape.md
+++ b/agent-os/specs/2026-05-05-1500-open-project-file-browser/shape.md
@@ -1,0 +1,26 @@
+# Open Project File Browser — Shaping Notes
+
+## Scope
+
+Replace the placeholder `OpenProjectPopupWindow` (hardcoded path, Create/Cancel buttons) with a functional custom ImGui file browser. The user navigates the filesystem, finds a `.proj` file, clicks it, and the project loads.
+
+## Decisions
+
+- **Cross-platform ImGui browser** — no native OS dialogs (e.g. no Windows `IFileDialog`), so it works on Linux too
+- **Starting path:** `std::filesystem::current_path()` — repo root on both Windows and Linux when Edge is launched per CLAUDE.md
+- **Filter:** Show directories (navigation) + `.proj` files (selection) only; hide all other file types
+- **Selection:** Click a `.proj` file → strip `.proj` suffix → call `Storage->SetProjectPath(strippedPath)`. `ProjectSerializer::Deserialize` appends `.proj` itself, so we strip it before passing.
+- **Navigation:** Stack-based history (`std::stack<std::string>`), Back pops the stack (guarded to min size 1), Cancel closes without loading
+- **Layout:** 4-column `RazorImGui::BeginTable` grid with `ImageButton` + label per entry — same pattern as `AssetPickerPopupWindow`
+- **File extension:** `.proj` (not `.rzproj`) — matches current `ProjectSerializer` behavior
+
+## Context
+
+- **Visuals:** None provided
+- **References:** `AssetPickerPopupWindow` (file traversal + ImGui grid pattern), `OpenProjectPopupWindow` (current placeholder being replaced)
+- **Product alignment:** N/A — no `agent-os/product/` folder exists
+
+## Standards Applied
+
+- `editor/imgui-view-lifecycle` — use `RazorImGui::BeginPopupModal`, pair with `EndPopup`, `bIsOpen` boilerplate required
+- `editor/editor-storage` — use `Storage->SetProjectPath()` to broadcast delegate; do not call `Engine.LoadProject()` directly

--- a/agent-os/specs/2026-05-05-1500-open-project-file-browser/standards.md
+++ b/agent-os/specs/2026-05-05-1500-open-project-file-browser/standards.md
@@ -1,0 +1,62 @@
+# Standards for Open Project File Browser
+
+The following standards apply to this work.
+
+---
+
+## editor/imgui-view-lifecycle
+
+All editor views render via `RazorImGui::` — never call `ImGui::` directly. `RazorImGui` wraps ImGui to enforce consistent theming and allow backend swaps.
+
+### Required structure for every Render()
+
+```cpp
+void MyView::Render()
+{
+    bool bIsOpen;  // required by RazorImGui::Begin — declare even if never read
+    Razor::RazorImGui::Begin("My View", &bIsOpen);
+
+    // ... render content using RazorImGui:: calls
+
+    Razor::RazorImGui::End();
+}
+```
+
+- `bIsOpen` is required boilerplate — declare it, do not remove it
+- Pass `RazorGuiWindowFlags_MenuBar` as a third arg when the view has a menu bar
+- Always pair every `Begin` with `End` — early returns must call `End` first
+
+### Popups
+
+Use `BeginPopupModal` for blocking workflows (new project, open project). Use `BeginPopup` for non-blocking overlays (add component). Do not mix the two for the same concept.
+
+---
+
+## editor/editor-storage
+
+`EditorStorage` is the shared state bus for the Edge editor. It is passed as `Razor::Ref<EditorStorage>` to every view at startup.
+
+- All editor state that crosses view boundaries lives here (e.g. `SelectedEntity`, project path)
+- Engine-owned data (entities, components, scenes) stays in the engine layer — do not duplicate it in `EditorStorage`
+- Every editor view receives `EditorStorage` — no exceptions
+
+### Events
+
+Use `MulticastDelegate` members on `EditorStorage` for cross-view notifications:
+
+```cpp
+// Declare in EditorStorage.h
+OnProjectSetDelegate ProjectSetDelegate;
+public:
+  OnProjectSetDelegate& OnProjectSet() { return ProjectSetDelegate; }
+  void SetProjectPath(const std::string& Proj) {
+      _mCurrentProjectPath = Proj;
+      ProjectSetDelegate.Broadcast();
+  }
+
+// Subscribe in EdgeApp.cpp or view constructor
+Storage->OnProjectSet().AddRaw(this, &Edge::OnNewProjectSet);
+```
+
+- Never call view methods directly — broadcast events and let subscribers react
+- Add new events as delegate members on `EditorStorage`, not as direct function calls


### PR DESCRIPTION
## Description ##

This change alters the open project popup to actually have a in-editor file explorer to it to allow the user to move through the file structure and select their .proj file that they would like to load.

### Changes ###
- Expanded OpenProjectPopupWindow to actually have a file explorer like window to allow navigation, current drawback is you can't navigate back up the way from where it opened
- Upgraded script bridge & game dlls to use net9.0
- Altered logic for scraping script types from game dll to use ptr to types rather than ref
- In ScriptInterface moved us to using absolute path over relative path