### PR TITLE
fix [Engine]: Altered read path for shaders to be properly set

### DIFF
--- a/Razor/src/Razor/ShaderReader.cpp
+++ b/Razor/src/Razor/ShaderReader.cpp
@@ -11,7 +11,7 @@ namespace Razor
 
     std::string ShaderReader::ReadInShader(std::string shaderName)
     {
-        std::ifstream t("resources/shaders/" + shaderName);
+        std::ifstream t("Edge/resources/shaders/" + shaderName);
         std::stringstream buffer;
         buffer << t.rdbuf();
         return buffer.str();


### PR DESCRIPTION
## Description ##
This change fixes the loading of shaders by fixing up the loading path.