### PR TITLE
feature [Editor]: Simulating in-editor doesn't alter scene when stopped

### DIFF
--- a/Edge/src/EdgeApp.cpp
+++ b/Edge/src/EdgeApp.cpp
@@ -247,7 +247,7 @@ void Edge::CreateDockspace(const std::string& Title)
 		{
 			if (Razor::RazorImGui::MenuItem("Play"))
 			{
-				if (!_mPlaybackSceneBackup)
+				if (!Razor::Engine::Get().IsRuntimeRunning())
 				{
 					Razor::Engine& engine = Razor::Engine::Get();
 					_mPlaybackSceneBackup = engine.CurrentScene->Clone();

--- a/Edge/src/EdgeApp.cpp
+++ b/Edge/src/EdgeApp.cpp
@@ -54,6 +54,7 @@ private:
 	Razor::Vector2 ViewportPos { 0.0f, 0.0f }; /** 2D vector to hold position of image displaying scene texture for viewport*/
 	Razor::Ref<EdgeEditor::EditorStorage> Storage; /** Container object to hold data to be shared among windows*/
 	EdgeEditor::ProjectExplorer _mProjectExplorerWindow;
+	Razor::Ref<Razor::Scene> _mPlaybackSceneBackup;
 };
 
 Razor::Application* Razor::CreateApplication()
@@ -246,11 +247,13 @@ void Edge::CreateDockspace(const std::string& Title)
 		{
 			if (Razor::RazorImGui::MenuItem("Play"))
 			{
-				Razor::Engine::Get().RuntimeStart();
+				if (!_mPlaybackSceneBackup)
+					_mPlaybackSceneBackup = Razor::Engine::Get().RuntimeStart();
 			}
 			if (Razor::RazorImGui::MenuItem("Stop"))
 			{
-				Razor::Engine::Get().RuntimeStop();
+				Razor::Engine::Get().RuntimeStop(_mPlaybackSceneBackup);
+				_mPlaybackSceneBackup = nullptr;
 			}
 			Razor::RazorImGui::EndMenu();
 		}

--- a/Edge/src/EdgeApp.cpp
+++ b/Edge/src/EdgeApp.cpp
@@ -248,11 +248,18 @@ void Edge::CreateDockspace(const std::string& Title)
 			if (Razor::RazorImGui::MenuItem("Play"))
 			{
 				if (!_mPlaybackSceneBackup)
-					_mPlaybackSceneBackup = Razor::Engine::Get().RuntimeStart();
+				{
+					Razor::Engine& engine = Razor::Engine::Get();
+					_mPlaybackSceneBackup = engine.CurrentScene->Clone();
+					engine.RuntimeStart();
+				}
 			}
 			if (Razor::RazorImGui::MenuItem("Stop"))
 			{
-				Razor::Engine::Get().RuntimeStop(_mPlaybackSceneBackup);
+				Razor::Engine& engine = Razor::Engine::Get();
+				engine.RuntimeStop();
+				if (_mPlaybackSceneBackup)
+					*engine.CurrentScene = std::move(*_mPlaybackSceneBackup);
 				_mPlaybackSceneBackup = nullptr;
 			}
 			Razor::RazorImGui::EndMenu();

--- a/Razor/src/Razor/Engine.cpp
+++ b/Razor/src/Razor/Engine.cpp
@@ -257,17 +257,22 @@ namespace Razor
 		_mAssetDirectory = CreateRef<AssetDirectory>(Path + "/" + LoadedProject->m_AssetDirectory);
 	}
 
-	void Engine::RuntimeStart()
+	Ref<Scene> Engine::RuntimeStart()
 	{
 		if(bIsRuntimeRunning.load())
 		{
 			RZ_CORE_WARN("Runtime is already running");
-			return;
+			return nullptr;
 		}
 		RZ_CORE_INFO("Starting Runtime");
+
+		Ref<Scene> backup = CurrentScene->Clone();
+
 		bIsRuntimeRunning.store(true);
 		CurrentScene->StartScene();
 		RuntimeThread = std::thread(&Engine::RunRuntime, this);
+
+		return backup;
 	}
 
 	void Engine::RunRuntime()
@@ -283,7 +288,7 @@ namespace Razor
 		RZ_CORE_INFO("Exiting Runtime Thread");
 	}
 
-	void Engine::RuntimeStop()
+	void Engine::RuntimeStop(Ref<Scene> backup)
 	{
 		RZ_CORE_INFO("Stopping Runtime");
 		bIsRuntimeRunning.store(false);
@@ -292,6 +297,8 @@ namespace Razor
 			RuntimeThread.join();
 			CurrentScene->StopScene();
 		}
+		if (backup)
+			*CurrentScene = std::move(*backup);
 	}
 
 	Ref<AssetDirectory> Engine::GetAssetDirectory()

--- a/Razor/src/Razor/Engine.cpp
+++ b/Razor/src/Razor/Engine.cpp
@@ -265,7 +265,6 @@ namespace Razor
 			return;
 		}
 		RZ_CORE_INFO("Starting Runtime");
-
 		bIsRuntimeRunning.store(true);
 		CurrentScene->StartScene();
 		RuntimeThread = std::thread(&Engine::RunRuntime, this);

--- a/Razor/src/Razor/Engine.cpp
+++ b/Razor/src/Razor/Engine.cpp
@@ -257,22 +257,18 @@ namespace Razor
 		_mAssetDirectory = CreateRef<AssetDirectory>(Path + "/" + LoadedProject->m_AssetDirectory);
 	}
 
-	Ref<Scene> Engine::RuntimeStart()
+	void Engine::RuntimeStart()
 	{
 		if(bIsRuntimeRunning.load())
 		{
 			RZ_CORE_WARN("Runtime is already running");
-			return nullptr;
+			return;
 		}
 		RZ_CORE_INFO("Starting Runtime");
-
-		Ref<Scene> backup = CurrentScene->Clone();
 
 		bIsRuntimeRunning.store(true);
 		CurrentScene->StartScene();
 		RuntimeThread = std::thread(&Engine::RunRuntime, this);
-
-		return backup;
 	}
 
 	void Engine::RunRuntime()
@@ -288,7 +284,7 @@ namespace Razor
 		RZ_CORE_INFO("Exiting Runtime Thread");
 	}
 
-	void Engine::RuntimeStop(Ref<Scene> backup)
+	void Engine::RuntimeStop()
 	{
 		RZ_CORE_INFO("Stopping Runtime");
 		bIsRuntimeRunning.store(false);
@@ -297,8 +293,6 @@ namespace Razor
 			RuntimeThread.join();
 			CurrentScene->StopScene();
 		}
-		if (backup)
-			*CurrentScene = std::move(*backup);
 	}
 
 	Ref<AssetDirectory> Engine::GetAssetDirectory()

--- a/Razor/src/Razor/Engine.h
+++ b/Razor/src/Razor/Engine.h
@@ -163,6 +163,7 @@ namespace Razor
 
 		void RuntimeStart();
 		void RuntimeStop();
+		bool IsRuntimeRunning() const { return bIsRuntimeRunning.load(); }
 
 		Ref<Scene> CurrentScene; /** Ref to the current scene we have*/
 

--- a/Razor/src/Razor/Engine.h
+++ b/Razor/src/Razor/Engine.h
@@ -161,8 +161,8 @@ namespace Razor
 		void SaveProject();
 		void LoadProject(const std::string& ProjectPath);
 
-		Ref<Scene> RuntimeStart();
-		void RuntimeStop(Ref<Scene> backup);
+		void RuntimeStart();
+		void RuntimeStop();
 
 		Ref<Scene> CurrentScene; /** Ref to the current scene we have*/
 

--- a/Razor/src/Razor/Engine.h
+++ b/Razor/src/Razor/Engine.h
@@ -161,8 +161,8 @@ namespace Razor
 		void SaveProject();
 		void LoadProject(const std::string& ProjectPath);
 
-		void RuntimeStart();
-		void RuntimeStop();
+		Ref<Scene> RuntimeStart();
+		void RuntimeStop(Ref<Scene> backup);
 
 		Ref<Scene> CurrentScene; /** Ref to the current scene we have*/
 

--- a/Razor/src/Razor/Scene/Scene.cpp
+++ b/Razor/src/Razor/Scene/Scene.cpp
@@ -10,6 +10,17 @@
 #include "../Physics/Components/BoxBody.h"
 #include "../Physics/IPhysicsEngine.h"
 
+namespace
+{
+	template<typename T>
+	void CopyComponent(const entt::registry& src, entt::registry& dst,
+		const std::unordered_map<entt::entity, entt::entity>& map)
+	{
+		for (auto [entity, component] : src.view<const T>().each())
+			dst.emplace<T>(map.at(entity), component);
+	}
+}
+
 namespace Razor
 {
 	Scene::Scene(const std::string& Path)
@@ -19,6 +30,30 @@ namespace Razor
 	Scene::~Scene()
 	{
 
+	}
+
+	Ref<Scene> Scene::Clone() const
+	{
+		auto copy = CreateRef<Scene>(FilePath);
+		copy->mSystemInstanceHandles = mSystemInstanceHandles;
+
+		std::unordered_map<entt::entity, entt::entity> entityMap;
+		for (auto e : registry.view<Transform>())
+			entityMap[e] = copy->registry.create();
+
+		CopyComponent<Transform>       (registry, copy->registry, entityMap);
+		CopyComponent<ScriptComponent> (registry, copy->registry, entityMap);
+		CopyComponent<Mesh>            (registry, copy->registry, entityMap);
+		CopyComponent<Camera>          (registry, copy->registry, entityMap);
+		CopyComponent<CameraInfo>      (registry, copy->registry, entityMap);
+		CopyComponent<DirectionalLight>(registry, copy->registry, entityMap);
+		CopyComponent<PointLight>      (registry, copy->registry, entityMap);
+		CopyComponent<SpotLight>       (registry, copy->registry, entityMap);
+		CopyComponent<Collider>        (registry, copy->registry, entityMap);
+		CopyComponent<BoxBody>         (registry, copy->registry, entityMap);
+		CopyComponent<Input>           (registry, copy->registry, entityMap);
+
+		return copy;
 	}
 
 	Ref<Entity> Scene::CreateEntity()

--- a/Razor/src/Razor/Scene/Scene.cpp
+++ b/Razor/src/Razor/Scene/Scene.cpp
@@ -238,7 +238,8 @@ namespace Razor
 		for (auto entity : GetEntitiesWithComponents<BoxBody>())
 		{
 			BoxBody body = GetEntity(entity)->GetComponent<BoxBody>();
-			Engine::Get().GetPhysicsEngine().DestroyBody(body.bodyId);
+			if (body.bodyId != 0xFFFFFFFF)
+				Engine::Get().GetPhysicsEngine().DestroyBody(body.bodyId);
 		}
 	}
 

--- a/Razor/src/Razor/Scene/Scene.h
+++ b/Razor/src/Razor/Scene/Scene.h
@@ -1,7 +1,9 @@
 #pragma once
 #include <entt/entt.hpp>
 #include "../Core.h"
+#include "../Component.h"
 #include <vector>
+#include <unordered_map>
 
 namespace Razor
 {
@@ -31,6 +33,8 @@ namespace Razor
 
 		std::string& GetPath() { return FilePath; }
 
+		Ref<Scene> Clone() const;
+
 		Ref<Entity> CreateEntity();
 
 		Ref<Entity> GetEntity(entt::entity EntityHandle);
@@ -55,8 +59,6 @@ namespace Razor
 		void CreateInstanceObjects(std::vector<uint64_t> handles);
 		void PopulateObjectFields(ScriptInstance& instance, uint64_t objId);
 		void StopScene();
-
-		
 
 		entt::registry registry;
 	private:

--- a/Razor/src/Razor/Scripting/ScriptInterface.cpp
+++ b/Razor/src/Razor/Scripting/ScriptInterface.cpp
@@ -141,8 +141,9 @@ namespace Razor
 	void ScriptInterface::DestroyInstanceObject(int handle)
 	{
 		ScriptInstance& instance = GetScriptInstance(handle);
-		Ref<Coral::ManagedObject> object = GetManagedObject(handle);
-		object->Destroy();
+		Ref<Coral::ManagedObject> object = GetManagedObject(instance.handle);
+		if (object)
+			object->Destroy();
 		instance.handle = 0;
 	}
 

--- a/agent-os/product/mission.md
+++ b/agent-os/product/mission.md
@@ -1,0 +1,19 @@
+# Product Mission
+
+## Problem
+
+Building strategy and simulation games requires an engine that can efficiently handle large numbers of active entities without the overhead and complexity of general-purpose commercial engines. Existing options (Unity, Unreal, Godot) are either too heavy, too opaque, or not designed with ECS-first thinking that suits simulation workloads.
+
+## Target Users
+
+Hobbyist and indie developers who want a lightweight, approachable engine for strategy and simulation games. Also open-source contributors and learners who want to understand engine internals by reading and modifying real, working code.
+
+## Solution
+
+Razor is a lightweight, hackable 3D game engine built from scratch in C++20. It is:
+
+- **ECS-first** — built around EnTT from the ground up, making it naturally suited to simulations with hundreds or thousands of entities
+- **Transparent** — a small, understandable codebase where every layer is accessible and modifiable
+- **Complete enough to ship** — includes a visual scene editor (Edge), C# scripting via Coral, Jolt physics, and OpenGL rendering out of the box
+
+The goal is not the best graphics or the fastest iteration time — it is an engine you can fully understand, extend, and learn from.

--- a/agent-os/product/roadmap.md
+++ b/agent-os/product/roadmap.md
@@ -1,0 +1,19 @@
+# Product Roadmap
+
+## Phase 1: MVP
+
+Core systems that make Razor usable for building strategy/simulation games:
+
+- **Visual scene editor (Edge)** — scene hierarchy, entity inspector, asset browser, project management
+- **ECS with core components** — Transform, Mesh, Camera, Lights, Collider, and ScriptComponent working reliably via EnTT
+- **C# scripting** — game logic attached to entities through the Coral .NET bridge
+- **Physics simulation** — Jolt-based rigid body physics with collider components
+
+## Phase 2: Post-Launch
+
+Features planned after the MVP is stable:
+
+- **AI & pathfinding** — navigation mesh generation and agent steering systems suited to simulation entities
+- **Rendering improvements** — shadows, post-processing effects, particle systems, material editor enhancements
+- **Editor tooling improvements** — better workflow, more panels, undo/redo, improved scene manipulation
+- **Asset importing** — robust pipeline for importing meshes, textures, and other assets into projects

--- a/agent-os/product/tech-stack.md
+++ b/agent-os/product/tech-stack.md
@@ -1,0 +1,50 @@
+# Tech Stack
+
+## Language & Standard
+
+- **C++20** — engine and editor
+- **C#/.NET 9** — game scripting layer (Sandbox scripts, script bridge)
+
+## Rendering
+
+- **OpenGL** — rendering backend
+- **GLFW** — window and input management
+- **Dear ImGui** — editor UI
+
+## Entity Component System
+
+- **EnTT** — ECS registry, component storage, and entity management
+
+## Physics
+
+- **JoltPhysics** — rigid body simulation, built from source with RTTI enabled
+
+## Scripting Bridge
+
+- **Coral** — .NET assembly hosting; allows C# scripts to attach to entities at runtime
+
+## Serialization
+
+- **yaml-cpp** — scene and project file serialization
+
+## Build System
+
+- **Premake5** — generates Visual Studio (Windows) and Makefile (Linux) project files
+- **MSBuild / make** — build execution
+- JoltPhysics and Assimp are built from source via CMake pre-build steps
+
+## Asset Pipeline
+
+- **Assimp** — mesh and scene asset importing (built from source)
+
+## Platform Support
+
+- **Windows** — primary platform (Visual Studio 2022)
+- **Linux** — supported (GLFW Wayland, gmake build)
+
+## Output Structure
+
+- Engine compiled as a shared library (DLL on Windows, .so on Linux)
+- Editor: `Edge` application
+- Test/demo: `Sandbox` application
+- Build output: `bin/[Config]-[system]-x86_64/[Project]/`

--- a/agent-os/specs/2026-05-06-1900-runtime-scene-copy/plan.md
+++ b/agent-os/specs/2026-05-06-1900-runtime-scene-copy/plan.md
@@ -1,0 +1,55 @@
+# Runtime Scene Copy
+
+## Context
+
+The editor currently runs the simulation on the live `CurrentScene`. Physics mutates `Transform.Position`, C# scripts can mutate component fields, and stopping the runtime leaves the scene dirty. The fix is to deep-clone the scene before play, run on the clone, and discard it on stop — restoring the original editor scene ref unchanged.
+
+## Approach
+
+Add `Scene::Clone()` which builds a fresh `entt::registry` by iterating all component types and emplacing copies, then update `Engine::RuntimeStart` / `RuntimeStop` to swap `CurrentScene` with the clone.
+
+---
+
+## Task 1: Save Spec Documentation ✓
+
+`agent-os/specs/2026-05-06-1900-runtime-scene-copy/` created with plan.md, shape.md, standards.md, references.md.
+
+---
+
+## Task 2: Add `Scene::Clone()`
+
+**Files:** `Razor/src/Razor/Scene/Scene.h`, `Razor/src/Razor/Scene/Scene.cpp`
+
+Add public `Ref<Scene> Clone() const;` to Scene.h.
+
+In Scene.cpp, add a file-local template helper and implement Clone():
+- Create a new Scene with the same FilePath
+- Copy mSystemInstanceHandles (vector copy)
+- Build entity map: `registry.each()` → `copy->registry.create()`
+- Emplace each component type using the map
+
+Components to copy: `Transform`, `ScriptComponent`, `Mesh`, `Camera`, `CameraInfo`, `DirectionalLight`, `PointLight`, `SpotLight`, `Collider`, `BoxBody`, `Input`.
+
+Do NOT use `CreateEntity()` — it double-adds mandatory components.
+
+---
+
+## Task 3: Update Engine RuntimeStart / RuntimeStop
+
+**Files:** `Razor/src/Razor/Engine.h`, `Razor/src/Razor/Engine.cpp`
+
+Add `Ref<Scene> _mEditorScene;` to private section of Engine.h.
+
+RuntimeStart: save `CurrentScene` to `_mEditorScene`, assign `CurrentScene->Clone()` to `CurrentScene`, then proceed with StartScene + thread spawn as before.
+
+RuntimeStop: after joining thread and calling StopScene, restore `CurrentScene = _mEditorScene` and reset `_mEditorScene = nullptr`.
+
+---
+
+## Verification
+
+1. Build with MSBuild — 0 errors expected.
+2. Run Edge, load a scene with physics/script entities.
+3. Note entity positions. Press Play, observe mutation. Press Stop.
+4. Confirm positions match pre-play values.
+5. Repeat Play/Stop to verify second cycle works correctly.

--- a/agent-os/specs/2026-05-06-1900-runtime-scene-copy/references.md
+++ b/agent-os/specs/2026-05-06-1900-runtime-scene-copy/references.md
@@ -1,0 +1,18 @@
+# References for Runtime Scene Copy
+
+## Scene::MoveFrom
+
+- **Location:** `Razor/src/Razor/Scene/Scene.cpp:210–215`
+- **Relevance:** Enumerates every field that belongs to a Scene: `registry`, `FilePath`, `mSystemInstanceHandles`. Clone must handle the same set.
+- **Key pattern:** Fields are moved, not copied. Clone does the same but by value-copy or `registry` component iteration.
+
+## Engine::LoadProject
+
+- **Location:** `Razor/src/Razor/Engine.cpp:248–256`
+- **Relevance:** Established pattern for creating a `Ref<Scene>` and populating it before making it `CurrentScene`.
+- **Key pattern:** `CreateRef<Scene>(path)` → populate → assign to `CurrentScene`. Clone follows the same shape.
+
+## Scene::StartScene / StopScene
+
+- **Location:** `Razor/src/Razor/Scene/Scene.cpp:69–208`
+- **Relevance:** Shows exactly what state is created at play-start (physics bodies, C# instances) and destroyed at play-stop. The clone is the target of both calls; the editor scene ref must never pass through either.

--- a/agent-os/specs/2026-05-06-1900-runtime-scene-copy/shape.md
+++ b/agent-os/specs/2026-05-06-1900-runtime-scene-copy/shape.md
@@ -1,0 +1,30 @@
+# Runtime Scene Copy — Shaping Notes
+
+## Scope
+
+When the editor starts play mode, the simulation currently runs directly on the live editor scene. Physics updates entity transforms, C# scripts mutate component data, and when the user stops the runtime those mutations persist in the editor — the scene is dirty.
+
+We want to:
+1. Deep-copy the editor scene immediately before play starts
+2. Run the simulation on the copy
+3. On stop, destroy the copy and restore `CurrentScene` to the original editor scene ref
+
+## Decisions
+
+- **Copy mechanism:** Deep copy via `Scene::Clone()` — builds an entity map and copies each component type manually. Chosen over the YAML serialize/deserialize approach because it avoids YAML parsing overhead, keeps all logic in C++, and is more semantically clear.
+- **Restore behavior:** Full restore to pre-play state. Runtime mutations are discarded on stop.
+- **No UI change needed:** Play/Stop buttons in `Edge::CreateDockspace()` already call `Engine::RuntimeStart()` / `Engine::RuntimeStop()` — all logic stays inside the Engine.
+- **Pointer swap:** We save the original `CurrentScene` shared_ptr as `_mEditorScene` and assign the cloned `Ref<Scene>` to `CurrentScene`. The original scene object is never touched during play.
+- **`ScriptComponent` handle sharing is safe:** `mScriptInstances` contains `uint64_t` handles into `ScriptInterface::ScriptInstancePool`. The only field mutated at play-time is `ScriptInstance::handle` (the C# object ID), which is re-set on every `StartScene()` call. `className` and `fields` are read-only during play.
+- **`BoxBody::bodyId` is pre-play clean:** Default value is `0xFFFFFFFF`, only set during `StartScene()`. A copy made before play has correct defaults.
+
+## Context
+
+- **Visuals:** None
+- **References:** `Engine::LoadProject()` (`Engine.cpp:248–256`) — shows the established pattern for creating a `Ref<Scene>` and deserializing into it before assigning to `CurrentScene`. `Scene::MoveFrom()` (`Scene.cpp:210–215`) — shows all fields that need to be handled: `registry`, `FilePath`, `mSystemInstanceHandles`.
+- **Product alignment:** Direct MVP requirement — Edge is not usable as a game editor without play-mode isolation
+
+## Standards Applied
+
+- `ecs/smart-pointer-aliases` — Use `CreateRef<Scene>` when constructing the clone
+- `ecs/mandatory-components` — Every entity has `Transform` and `ScriptComponent`; clone must cover both

--- a/agent-os/specs/2026-05-06-1900-runtime-scene-copy/standards.md
+++ b/agent-os/specs/2026-05-06-1900-runtime-scene-copy/standards.md
@@ -1,0 +1,20 @@
+# Standards for Runtime Scene Copy
+
+## ecs/smart-pointer-aliases
+
+Razor defines aliases for `std::shared_ptr` and `std::unique_ptr`. Always use the aliases and their factory functions — never use `std::make_shared`, `std::make_unique`, or `new` directly.
+
+| Alias | Underlying type | Factory |
+|---|---|---|
+| `Ref<T>` | `std::shared_ptr<T>` | `CreateRef<T>(args...)` |
+| `Scope<T>` | `std::unique_ptr<T>` | `CreateScope<T>(args...)` |
+
+Use `CreateRef<Scene>(path)` when constructing the clone inside `Scene::Clone()`.
+
+## ecs/mandatory-components
+
+`Scene::CreateEntity` always adds `Transform` and `ScriptComponent`. The clone must include both in its per-component copy loop. Do not call `CreateEntity()` when cloning — create raw registry entities and emplace components directly to avoid double-adding mandatory components.
+
+## ecs/entity-wrapper
+
+`Entity` is a disposable proxy; use `entt::entity` handles directly when iterating in systems and in `Scene::Clone()`. The entity map in `Clone()` should be `std::unordered_map<entt::entity, entt::entity>`.


### PR DESCRIPTION
## Description ##
This change adds in the feature of copying the scene before simulating with it so that we can restore the scene to how it was before the simulation was ran at the end.

## Changes ##
- Add var to EdgeApp to hold backup scene
- Added guard to not overwrite scene if play was pressed twice
- Added cloning logic to Editor before Runtime starts 
- Added CopyComponent function to Scene.cpp
- Added Clone function to Scene object to clone
- Misc: Added product roadmap agentic markdown files
