### PR TITLE
feature: Create pong

### DIFF
--- a/Edge/src/Gui/ComponentImGui.cpp
+++ b/Edge/src/Gui/ComponentImGui.cpp
@@ -77,6 +77,10 @@ namespace EdgeEditor
 						_mAssetPickerPopup = nullptr;
 					}
 				}
+				if(Razor::RazorImGui::Button("Remove Component", {200.0f, 30.0f}))
+				{
+					InEntity->RemoveComponent<Razor::Mesh>();
+				}
 			}
 		}
 	}
@@ -88,7 +92,10 @@ namespace EdgeEditor
 			Razor::DirectionalLight& mesh = InEntity->GetComponent<Razor::DirectionalLight>();
 			if (Razor::RazorImGui::CollapsingHeader("Directional Light"))
 			{
-				// Nothing really here to show just now maybe in the future but at least we know it's there
+				if(Razor::RazorImGui::Button("Remove Component", {200.0f, 30.0f}))
+				{
+					InEntity->RemoveComponent<Razor::DirectionalLight>();
+				}
 			}
 		}
 	}
@@ -98,6 +105,8 @@ namespace EdgeEditor
 		if (InEntity->HasComponent<Razor::ScriptComponent>())
 		{
 			Razor::ScriptComponent& scriptComp = InEntity->GetComponent<Razor::ScriptComponent>();
+			std::vector<int> instancesToRemove;
+			int i = 0;
 			for (uint64_t instanceID : scriptComp.mScriptInstances)
 			{
 				Razor::ScriptInstance& instance = Razor::Engine::Get().GetScriptInterface().GetScriptInstance(instanceID);
@@ -117,9 +126,26 @@ namespace EdgeEditor
 							}
 						}
 					}
+					if(Razor::RazorImGui::Button("Remove Component", {200.0f, 30.0f}))
+					{
+						instancesToRemove.push_back(i);
+					}
 				}
+				i += 1;
 			}
 			
+			for (int idx : instancesToRemove)
+			{
+				std::vector<size_t>::iterator it = scriptComp.mScriptInstances.begin();
+				it += idx;
+				scriptComp.mScriptInstances.erase(it);
+			}
+			instancesToRemove.clear();
+
+			if(scriptComp.mScriptInstances.size() == 0)
+			{
+				InEntity->RemoveComponent<Razor::ScriptComponent>();
+			}
 		}
 	}
 
@@ -171,6 +197,10 @@ namespace EdgeEditor
 					}
 					
 				}
+				if(Razor::RazorImGui::Button("Remove Component", {200.0f, 30.0f}))
+				{
+					inEntity->RemoveComponent<Razor::BoxBody>();
+				}
 			}
 		}
 	}
@@ -182,7 +212,10 @@ namespace EdgeEditor
 			Razor::Camera& camera = InEntity->GetComponent<Razor::Camera>();
 			if (Razor::RazorImGui::CollapsingHeader("Camera"))
 			{
-
+				if(Razor::RazorImGui::Button("Remove Component", {200.0f, 30.0f}))
+				{
+					InEntity->RemoveComponent<Razor::Camera>();
+				}
 			}
 		}
 	}
@@ -190,7 +223,15 @@ namespace EdgeEditor
 	void ComponentImGui::DrawCollisionComponent(Razor::Ref<Razor::Entity> InEntity)
 	{
 		if (InEntity->HasComponent<Razor::CollisionComponent>())
-			Razor::RazorImGui::CollapsingHeader("Collision");
+		{
+			if (Razor::RazorImGui::CollapsingHeader("Collision"))
+			{
+				if(Razor::RazorImGui::Button("Remove Component", {200.0f, 30.0f}))
+				{
+					InEntity->RemoveComponent<Razor::CollisionComponent>();
+				}
+			}
+		}
 	}
 
 
@@ -236,6 +277,10 @@ namespace EdgeEditor
 				if (Razor::RazorImGui::ColorPicker("Text Color", color))
 				{
 					text.mColor = Razor::Vector3{color[0], color[1], color[2]};
+				}
+				if(Razor::RazorImGui::Button("Remove Component", {200.0f, 30.0f}))
+				{
+					InEntity->RemoveComponent<Razor::Text>();
 				}
 			}
 		}

--- a/Edge/src/Gui/ComponentImGui.cpp
+++ b/Edge/src/Gui/ComponentImGui.cpp
@@ -125,6 +125,14 @@ namespace EdgeEditor
 								field.SetValue<std::string>(std::string(buffer));
 							}
 						}
+						else if (type == Razor::ScriptFieldType::Int)
+						{
+							Razor::Ref<int> value = Razor::CreateRef<int>(field.GetValue<int>());
+							if (Razor::RazorImGui::InputInt(field.Field.Name.c_str(), value))
+							{
+								field.SetValue<int>(*value);
+							}
+						}
 					}
 					if(Razor::RazorImGui::Button("Remove Component", {200.0f, 30.0f}))
 					{
@@ -226,6 +234,11 @@ namespace EdgeEditor
 		{
 			if (Razor::RazorImGui::CollapsingHeader("Collision"))
 			{
+				Razor::CollisionComponent& collision = InEntity->GetComponent<Razor::CollisionComponent>();
+				if(Razor::RazorImGui::CheckBox("Is Trigger", &collision.bIsTrigger))
+				{
+					
+				}
 				if(Razor::RazorImGui::Button("Remove Component", {200.0f, 30.0f}))
 				{
 					InEntity->RemoveComponent<Razor::CollisionComponent>();

--- a/Edge/src/Gui/ComponentImGui.cpp
+++ b/Edge/src/Gui/ComponentImGui.cpp
@@ -43,9 +43,21 @@ namespace EdgeEditor
 			{
 				if (Razor::RazorImGui::CollapsingHeader("Position"))
 				{
-					Razor::RazorImGui::InputFloat("X", &transform.Position.x);
-					Razor::RazorImGui::InputFloat("Y", &transform.Position.y);
-					Razor::RazorImGui::InputFloat("Z", &transform.Position.z);
+					Razor::RazorImGui::InputFloat("Pos X", &transform.Position.x);
+					Razor::RazorImGui::InputFloat("Pos Y", &transform.Position.y);
+					Razor::RazorImGui::InputFloat("Pos Z", &transform.Position.z);
+				}
+				if (Razor::RazorImGui::CollapsingHeader("Scale"))
+				{
+					Razor::RazorImGui::InputFloat("Sca X", &transform.Scale.x);
+					Razor::RazorImGui::InputFloat("Sca Y", &transform.Scale.y);
+					Razor::RazorImGui::InputFloat("Sca Z", &transform.Scale.z);
+				}
+				if (Razor::RazorImGui::CollapsingHeader("Rotation"))
+				{
+					Razor::RazorImGui::InputFloat("Rot X", &transform.Rotation.x);
+					Razor::RazorImGui::InputFloat("Rot Y", &transform.Rotation.y);
+					Razor::RazorImGui::InputFloat("Rot Z", &transform.Rotation.z);
 				}
 			}
 		}
@@ -131,6 +143,14 @@ namespace EdgeEditor
 							if (Razor::RazorImGui::InputInt(field.Field.Name.c_str(), value))
 							{
 								field.SetValue<int>(*value);
+							}
+						}
+						else if (type == Razor::ScriptFieldType::Float)
+						{
+							Razor::Ref<float> value = Razor::CreateRef<float>(field.GetValue<float>());
+							if (Razor::RazorImGui::InputFloat(field.Field.Name.c_str(), value.get()))
+							{
+								field.SetValue<float>(*value);
 							}
 						}
 					}

--- a/Razor-ScriptBridge/Razor-ScriptBridge.csproj
+++ b/Razor-ScriptBridge/Razor-ScriptBridge.csproj
@@ -6,6 +6,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>Debug;Release;Dist</Configurations>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <Platforms>AnyCpu;arm64;x64</Platforms>
+    <Configurations>debug;distribution;release</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <PlatformTarget>x64</PlatformTarget>
@@ -55,6 +57,7 @@
     <Compile Include="Source\Razor\Log.cs" />
     <Compile Include="Source\Razor\Scene.cs" />
     <Compile Include="Source\Razor\System.cs" />
+    <Compile Include="Source\Razor\Text.cs" />
     <Compile Include="Source\Razor\Transform.cs" />
   </ItemGroup>
 </Project>

--- a/Razor-ScriptBridge/Source/Razor/Collision.cs
+++ b/Razor-ScriptBridge/Source/Razor/Collision.cs
@@ -10,6 +10,10 @@ namespace Razor
     {
         public CollisionEventType Type;
         public uint OtherEntityId;
+
+        public float[] hitX;
+        public float[] hitY;
+        public float[] hitZ;
     }
 
     public static class Collision

--- a/Razor-ScriptBridge/Source/Razor/InternalCalls.cs
+++ b/Razor-ScriptBridge/Source/Razor/InternalCalls.cs
@@ -19,7 +19,7 @@ namespace Razor
         internal static delegate* unmanaged[Cdecl]<uint, float*, float*, float*, void> Transform_GetPosition;
         internal static delegate* unmanaged[Cdecl]<uint, float, float, float, void>    Transform_SetPosition;
         internal static delegate* unmanaged[Cdecl]<uint, int>                          Collision_GetEventCount;
-        internal static delegate* unmanaged[Cdecl]<uint, int, int*, uint*, void>       Collision_GetEvent;
+        internal static delegate* unmanaged[Cdecl]<uint, int, int*, uint*, float**, float**, float**, int*, void>       Collision_GetEvent;
          internal static delegate* unmanaged[Cdecl]<uint, IntPtr, void>				Text_SetText;
         internal static delegate* unmanaged[Cdecl]<uint, byte*, int, void>			Text_GetText;
         internal static delegate* unmanaged[Cdecl]<uint, float, float, float, void>	Text_SetColor;
@@ -111,8 +111,10 @@ namespace Razor
         public static CollisionEvent CollisionGetEvent(uint entityId, int index)
         {
             int type; uint otherId;
-            Collision_GetEvent(entityId, index, &type, &otherId);
-            return new CollisionEvent { Type = (CollisionEventType)type, OtherEntityId = otherId };
+            float* x, y, z;
+            int hitLength;
+            Collision_GetEvent(entityId, index, &type, &otherId, &x, &y, &z, &hitLength);
+            return new CollisionEvent { Type = (CollisionEventType)type, OtherEntityId = otherId, hitX = new ReadOnlySpan<float>(x, hitLength).ToArray(), hitY = new ReadOnlySpan<float>(y, hitLength).ToArray(), hitZ = new ReadOnlySpan<float>(z, hitLength).ToArray() };
         }
 
         public static T GetComponent<T>(uint entityId) where T : Component

--- a/Razor-ScriptBridge/Source/Razor/InternalCalls.cs
+++ b/Razor-ScriptBridge/Source/Razor/InternalCalls.cs
@@ -20,6 +20,11 @@ namespace Razor
         internal static delegate* unmanaged[Cdecl]<uint, float, float, float, void>    Transform_SetPosition;
         internal static delegate* unmanaged[Cdecl]<uint, int>                          Collision_GetEventCount;
         internal static delegate* unmanaged[Cdecl]<uint, int, int*, uint*, void>       Collision_GetEvent;
+         internal static delegate* unmanaged[Cdecl]<uint, IntPtr, void>				Text_SetText;
+        internal static delegate* unmanaged[Cdecl]<uint, byte*, int, void>			Text_GetText;
+        internal static delegate* unmanaged[Cdecl]<uint, float, float, float, void>	Text_SetColor;
+        internal static delegate* unmanaged[Cdecl]<uint, float, void>				Text_SetScale;
+        internal static delegate* unmanaged<int*, uint*>							Scene_GetEntitiesWithText;
 
         public static void LogMsg(string msg)
         {
@@ -127,5 +132,36 @@ namespace Razor
                 return obj as T;
             }
         }
+
+		 public static void TextSetText(uint entityId, string text)
+ 		{
+ 		    IntPtr p = Marshal.StringToHGlobalAnsi(text);
+ 		    try { Text_SetText(entityId, p); }
+ 		    finally { Marshal.FreeHGlobal(p); }
+ 		}
+		
+ 		public static string TextGetText(uint entityId)
+ 		{
+ 		    byte[] buffer = new byte[512];
+ 		    fixed (byte* buf = buffer)
+ 		        Text_GetText(entityId, buf, buffer.Length);
+ 		    return Encoding.UTF8.GetString(buffer).TrimEnd('\0');
+ 		}
+		
+ 		public static void TextSetColor(uint entityId, float r, float g, float b)
+ 		    => Text_SetColor(entityId, r, g, b);
+		
+ 		public static void TextSetScale(uint entityId, float scale)
+ 		    => Text_SetScale(entityId, scale);
+		
+ 		public static List<uint> GetEntitiesWithText()
+ 		{
+ 		    int count;
+ 		    uint* ptr = Scene_GetEntitiesWithText(&count);
+ 		    var entities = new List<uint>();
+ 		    for (int i = 0; i < count; i++)
+ 		        entities.Add(ptr[i]);
+ 		    return entities;
+ 		}
     }
 }

--- a/Razor-ScriptBridge/Source/Razor/Scene.cs
+++ b/Razor-ScriptBridge/Source/Razor/Scene.cs
@@ -6,21 +6,35 @@ using System.Threading.Tasks;
 
 namespace Razor
 {
-    public class Scene
-    {
-        public static List<UInt32> GetEntitiesWithTransforms()
-        {
-            return InternalCalls.GetEntitiesWithTransforms();
-        }
+	public class Scene
+	{
+		public static List<UInt32> GetEntitiesWithTransforms()
+		{
+			return InternalCalls.GetEntitiesWithTransforms();
+		}
 
-        public static uint[] GetEntitiesWithScriptComponent<T>()
-        {
-            return InternalCalls.GetEntitiesWithComponent<T>();
-        }
+		public static uint[] GetEntitiesWithScriptComponent<T>()
+		{
+			return InternalCalls.GetEntitiesWithComponent<T>();
+		}
 
-        public static T GetComponent<T>(uint entity) where T : Component
-        {
-            return InternalCalls.GetComponent<T>(entity);
-        }
-    }
+		public static T GetScriptComponent<T>(uint entity) where T : Component
+		{
+			return InternalCalls.GetComponent<T>(entity);
+		}
+
+		 public static List<uint> GetEntitiesWithNativeComponent<T>() where T : INativeComponent
+ 		{
+			 if (typeof(T) == typeof(Text))
+				 return InternalCalls.GetEntitiesWithText();
+			 throw new NotImplementedException($"Native component type {typeof(T).Name} is not registered.");
+ 		}
+
+ 		public static T GetNativeComponent<T>(uint entityId) where T : INativeComponent, new()
+ 		{
+			 if (typeof(T) == typeof(Text))
+				 return (T)(object)new Text(entityId);
+			 throw new NotImplementedException($"Native component type {typeof(T).Name} is not registered.");
+ 		}
+	}
 }

--- a/Razor-ScriptBridge/Source/Razor/Text.cs
+++ b/Razor-ScriptBridge/Source/Razor/Text.cs
@@ -1,0 +1,17 @@
+ namespace Razor
+ {
+     public interface INativeComponent { }
+
+     public class Text : INativeComponent
+     {
+         private readonly uint _entityId;
+
+         public Text() {}
+         public Text(uint entityId) { _entityId = entityId; }
+
+         public string GetText()                          => InternalCalls.TextGetText(_entityId);
+         public void   SetText(string text)               => InternalCalls.TextSetText(_entityId, text);
+         public void   SetColor(float r, float g, float b)=> InternalCalls.TextSetColor(_entityId, r, g, b);
+         public void   SetScale(float scale)              => InternalCalls.TextSetScale(_entityId, scale);
+     }
+ }

--- a/Razor/src/Razor/Component.h
+++ b/Razor/src/Razor/Component.h
@@ -19,7 +19,7 @@ namespace Razor
 		glm::vec3 Scale;
 		glm::vec3 Rotation;
 
-		Transform() : Position(0.0f, 0.0f, 0.0f), Scale(0.0f, 0.0f, 0.0f), Rotation(0.0f, 0.0f, 0.0f), RotationQ(0.0f, 0.0f, 0.0f, 1.0f) {}
+		Transform() : Position(0.0f, 0.0f, 0.0f), Scale(1.0f, 1.0f, 1.0f), Rotation(0.0f, 0.0f, 0.0f), RotationQ(0.0f, 0.0f, 0.0f, 1.0f) {}
 		Transform(glm::vec3 Pos, glm::vec3 Scl, glm::vec3 Rot) : Position(Pos), Scale(Scl), Rotation(Rot), RotationQ(0.0f, 0.0f, 0.0f, 1.0f) {}
 
 		void Rotate(glm::vec3 EulerAngles)
@@ -32,6 +32,7 @@ namespace Razor
 			glm::mat4 model = glm::mat4(1.0f);
 			model = glm::translate(model, Position);
 			model = model * glm::toMat4(RotationQ);
+			model = glm::scale(model, Scale);
 			return model;
 		}
 
@@ -144,6 +145,7 @@ namespace Razor
 	{
 		CollisionEventType Type;
 		uint32_t OtherEntityId;
+		std::vector<Vector3> mCollisionPoints;
 	};
 
 	struct CollisionComponent

--- a/Razor/src/Razor/Component.h
+++ b/Razor/src/Razor/Component.h
@@ -149,5 +149,6 @@ namespace Razor
 	struct CollisionComponent
 	{
 		std::vector<CollisionEvent> Events;
+		bool bIsTrigger;
 	};
 }

--- a/Razor/src/Razor/Core/Entity.cpp
+++ b/Razor/src/Razor/Core/Entity.cpp
@@ -7,6 +7,10 @@ namespace Razor
 {
 	void Entity::AddScriptComponent(std::string className)
 	{
+		if(!HasComponent<ScriptComponent>())
+		{
+			AddComponent<ScriptComponent>();
+		}
 		ScriptComponent& comp = GetComponent<ScriptComponent>();
 		ScriptInterface& interface = Engine::Get().GetScriptInterface();
 		int instanceId = interface.CreateScriptInstance(interface.GetType(className));

--- a/Razor/src/Razor/Core/Entity.h
+++ b/Razor/src/Razor/Core/Entity.h
@@ -31,6 +31,17 @@ namespace Razor
 			return _Scene->registry.get<T>(EntityHandle);
 		}
 
+		template<typename T>
+		bool RemoveComponent()
+		{
+			if(_Scene->registry.try_get<T>(EntityHandle))
+			{
+				_Scene->registry.remove<T>(EntityHandle);
+				return true;
+			}
+			return false;
+		}
+
 		entt::entity EntityHandle;
 
 	private:

--- a/Razor/src/Razor/Engine.cpp
+++ b/Razor/src/Razor/Engine.cpp
@@ -143,6 +143,10 @@ namespace Razor
 	void Engine::Step()
 	{
 		float CurrentFrame = TimeProvider->GetTime();
+		if(LastFrame == 0.0f)
+		{
+			LastFrame = TimeProvider->GetTime();
+		}
 		DeltaTime = CurrentFrame - LastFrame;
 		LastFrame = CurrentFrame;
 	}
@@ -228,6 +232,7 @@ namespace Razor
 		}
 
 		ProjectSerializer::Serialize(LoadedProject->m_ProjectPath, LoadedProject);
+		SceneSerializer::Serialize(CurrentScene);
 	}
 
 	void Engine::LoadProject(const std::string& ProjectPath)
@@ -293,6 +298,7 @@ namespace Razor
 			//ProcessInputForGame()
 			RunSystems();
 		}
+		LastFrame = 0.0f;
 		RZ_CORE_INFO("Exiting Runtime Thread");
 	}
 

--- a/Razor/src/Razor/ImGui/RazorImGui.cpp
+++ b/Razor/src/Razor/ImGui/RazorImGui.cpp
@@ -344,6 +344,15 @@ ImGuiViewport& RazorImGui::GetViewport(unsigned int ID)
 		return false;
 	}
 
+	bool RazorImGui::InputInt(const std::string& label, Ref<int> val)
+	{
+		if (ImGui::InputInt(label.c_str(), val.get()))
+		{
+			return true;
+		}
+		return false;
+	}
+
 	bool RazorImGui::CheckBox(const char* label, bool* value)
 	{
 		if (ImGui::Checkbox(label, value))

--- a/Razor/src/Razor/ImGui/RazorImGui.h
+++ b/Razor/src/Razor/ImGui/RazorImGui.h
@@ -124,6 +124,7 @@ namespace Razor
 		static void SetWindowSize(const Vector2& Size);
 		static bool Combo(const char* label, const char** data, int dataLength, int* selectedIdx);
 		static bool InputText(const char* label, char* buf, size_t bufSize);
+		static bool InputInt(const std::string& label, Ref<int> val);
 		static bool CheckBox(const char* label, bool* value);
 		static bool IsWindowHovered();
 		static bool ColorPicker(const std::string& label, Ref<float[]> color);

--- a/Razor/src/Razor/Physics/IPhysicsEngine.h
+++ b/Razor/src/Razor/Physics/IPhysicsEngine.h
@@ -25,6 +25,7 @@ namespace Razor
 		EContactType mContactType;
 		unsigned int mOtherBodyId;
 		bool mContactProcessed;
+		std::vector<Vector3> mCollisionPoints;
 		// TODO: extend with normal and penetration depth from JPH::ContactManifold when needed
 
 		bool operator==(const ContactInfo& other) const
@@ -40,7 +41,7 @@ namespace Razor
 		virtual void Simulate(float deltaTime) = 0;
 		virtual Vector3 GetPosition(unsigned int bodyId) const = 0;
 		virtual void ApplyLinearVelocity(unsigned int bodyId, const Vector3& velocity) = 0;
-		virtual unsigned int CreateBoxRigidBody(Vector3 position, float mass, EPhysicsMotionType motionType, bool bIsStatic, bool bIsTrigger) = 0;
+		virtual unsigned int CreateBoxRigidBody(Vector3 position, Vector3 scale, float mass, EPhysicsMotionType motionType, bool bIsStatic, bool bIsTrigger) = 0;
 		virtual void SetGravity(unsigned int bodyId, bool useGravity) = 0;
 		virtual void DestroyBody(unsigned int bodyId) = 0;
 		virtual std::vector<ContactInfo> GetContactInfo(unsigned int bodyId) = 0;

--- a/Razor/src/Razor/Physics/IPhysicsEngine.h
+++ b/Razor/src/Razor/Physics/IPhysicsEngine.h
@@ -40,10 +40,11 @@ namespace Razor
 		virtual void Simulate(float deltaTime) = 0;
 		virtual Vector3 GetPosition(unsigned int bodyId) const = 0;
 		virtual void ApplyLinearVelocity(unsigned int bodyId, const Vector3& velocity) = 0;
-		virtual unsigned int CreateBoxRigidBody(Vector3 position, float mass, EPhysicsMotionType motionType, bool bIsStatic) = 0;
+		virtual unsigned int CreateBoxRigidBody(Vector3 position, float mass, EPhysicsMotionType motionType, bool bIsStatic, bool bIsTrigger) = 0;
 		virtual void SetGravity(unsigned int bodyId, bool useGravity) = 0;
 		virtual void DestroyBody(unsigned int bodyId) = 0;
 		virtual std::vector<ContactInfo> GetContactInfo(unsigned int bodyId) = 0;
+		virtual void MoveKinematic(unsigned int bodyId, Vector3 position, float deltaTime) = 0;
 	};
 }
 

--- a/Razor/src/Razor/Physics/JoltPhysics/JoltPhysicsEngine.cpp
+++ b/Razor/src/Razor/Physics/JoltPhysics/JoltPhysicsEngine.cpp
@@ -165,6 +165,12 @@ namespace Razor
 		processContact(inSubShapePair.GetBody2ID(), inSubShapePair.GetBody1ID());
 	}
 
+	void MyContactListener::ClearContactMap()
+	{
+		std::scoped_lock lock(_mBodyContactMapMutex);
+		_mBodyContactMap.clear();
+	}
+
 	void MyBodyActivationListener::OnBodyActivated(const JPH::BodyID& inBodyID, uint64_t inBodyUserData)
 	{
 		std::cout << "A body got activated" << std::endl;
@@ -271,6 +277,7 @@ namespace Razor
 		if (accumulator >= fixedStep)
 		{
 			// Step the world
+			_mContactListener.ClearContactMap();
 			_mPhysicsSystem.Update(fixedStep, cCollisionSteps, _mTempAllocator.get(), _mJobSystem.get());
 			accumulator -= fixedStep;
 		}
@@ -305,7 +312,7 @@ namespace Razor
 		_mBodyInterface->SetLinearVelocity(JPH::BodyID(bodyId), jphVelocity);
 	}
 	
-	unsigned int JoltPhysicsEngine::CreateBoxRigidBody(Vector3 position, float mass, EPhysicsMotionType motionType, bool bIsStatic)
+	unsigned int JoltPhysicsEngine::CreateBoxRigidBody(Vector3 position, float mass, EPhysicsMotionType motionType, bool bIsStatic, bool bIsTrigger)
 	{
 		JPH::BodyInterface& interface = _mPhysicsSystem.GetBodyInterface();
 
@@ -341,6 +348,7 @@ namespace Razor
 		JPH::MassProperties massOverride;
 		massOverride.ScaleToMass(mass);
 		floor_settings.mMassPropertiesOverride = massOverride;
+		floor_settings.mIsSensor = bIsTrigger;
 
 		// Create the actual rigid body
 		JPH::Body* boxBody = interface.CreateBody(floor_settings); // Note that if we run out of bodies this can return nullptr
@@ -409,5 +417,12 @@ namespace Razor
 	std::vector<ContactInfo> JoltPhysicsEngine::GetContactInfo(unsigned int bodyId)
 	{
 		return _mContactListener.GetContactInfo(bodyId);
+	}
+
+	void JoltPhysicsEngine::MoveKinematic(unsigned int bodyId, Vector3 position, float deltaTime)
+	{
+		JPH::BodyInterface& interface = _mPhysicsSystem.GetBodyInterface();
+		//float deltaTime = 0.01f;
+		interface.MoveKinematic(static_cast<JPH::BodyID>(bodyId), JPH::RVec3Arg(position.X, position.Y, position.Z), interface.GetRotation(static_cast<JPH::BodyID>(bodyId)), deltaTime);
 	}
 }

--- a/Razor/src/Razor/Physics/JoltPhysics/JoltPhysicsEngine.cpp
+++ b/Razor/src/Razor/Physics/JoltPhysics/JoltPhysicsEngine.cpp
@@ -124,8 +124,23 @@ namespace Razor
 	void MyContactListener::OnContactAdded(const JPH::Body& inBody1, const JPH::Body& inBody2, const JPH::ContactManifold& inManifold, JPH::ContactSettings& ioSettings)
 	{
 		std::scoped_lock lock(_mBodyContactMapMutex);
-		_mBodyContactMap[inBody1.GetID()].push_back({ EContactType::Started, inBody2.GetID().GetIndex(), false });
-		_mBodyContactMap[inBody2.GetID()].push_back({ EContactType::Started, inBody1.GetID().GetIndex(), false });
+		std::vector<Vector3> body1ContactPoints;
+		JPH::RVec3 baseOffset = inManifold.mBaseOffset;
+		for (int i = 0; i < inManifold.mRelativeContactPointsOn1.size(); i++) 
+		{
+			JPH::Vec3 point = inManifold.mRelativeContactPointsOn1[i];
+			JPH::RVec3 worldContactPoint = baseOffset + point;
+			body1ContactPoints.push_back({worldContactPoint.GetX(), worldContactPoint.GetY(), worldContactPoint.GetZ()});
+		}
+		std::vector<Vector3> body2ContactPoints;
+		for (int i = 0; i < inManifold.mRelativeContactPointsOn2.size(); i++) 
+		{
+			JPH::Vec3 point = inManifold.mRelativeContactPointsOn2[i];
+			JPH::RVec3 worldContactPoint = baseOffset + point;
+			body2ContactPoints.push_back({worldContactPoint.GetX(), worldContactPoint.GetY(), worldContactPoint.GetZ()});
+		}
+		_mBodyContactMap[inBody1.GetID()].push_back({ EContactType::Started, inBody2.GetID().GetIndexAndSequenceNumber(), false, body1ContactPoints });
+		_mBodyContactMap[inBody2.GetID()].push_back({ EContactType::Started, inBody1.GetID().GetIndexAndSequenceNumber(), false, body2ContactPoints });
 	}
 
 	void MyContactListener::OnContactPersisted(const JPH::Body& inBody1, const JPH::Body& inBody2, const JPH::ContactManifold& inManifold, JPH::ContactSettings& ioSettings)
@@ -312,14 +327,14 @@ namespace Razor
 		_mBodyInterface->SetLinearVelocity(JPH::BodyID(bodyId), jphVelocity);
 	}
 	
-	unsigned int JoltPhysicsEngine::CreateBoxRigidBody(Vector3 position, float mass, EPhysicsMotionType motionType, bool bIsStatic, bool bIsTrigger)
+	unsigned int JoltPhysicsEngine::CreateBoxRigidBody(Vector3 position, Vector3 scale, float mass, EPhysicsMotionType motionType, bool bIsStatic, bool bIsTrigger)
 	{
 		JPH::BodyInterface& interface = _mPhysicsSystem.GetBodyInterface();
 
 		// Next we can create a rigid body to serve as the floor, we make a large box
 		// Create the settings for the collision volume (the shape).
 		// Note that for simple shapes (like boxes) you can also directly construct a BoxShape.
-		JPH::BoxShapeSettings floor_shape_settings(JPH::Vec3(1.0f, 1.0f, 1.0f));
+		JPH::BoxShapeSettings floor_shape_settings(JPH::Vec3(scale.X, scale.Y, scale.Z));
 		floor_shape_settings.SetEmbedded(); // A ref counted object on the stack (base class RefTarget) should be marked as such to prevent it from being freed when its reference count goes to 0.
 
 		// Create the shape

--- a/Razor/src/Razor/Physics/JoltPhysics/JoltPhysicsEngine.h
+++ b/Razor/src/Razor/Physics/JoltPhysics/JoltPhysicsEngine.h
@@ -108,7 +108,7 @@ namespace Razor
 		void Simulate(float deltaTime) override;
 		Vector3 GetPosition(unsigned int bodyId) const override;
 		void ApplyLinearVelocity(unsigned int bodyId, const Vector3& velocity) override;
-		unsigned int CreateBoxRigidBody(Vector3 position, float mass, EPhysicsMotionType motionType, bool bIsStatic, bool bIsTrigger) override;
+		unsigned int CreateBoxRigidBody(Vector3 position, Vector3 scale, float mass, EPhysicsMotionType motionType, bool bIsStatic, bool bIsTrigger) override;
 		void SetGravity(unsigned int bodyId, bool useGravity) override;
 		void DestroyBody(unsigned int bodyId) override;
 		std::vector<ContactInfo> GetContactInfo(unsigned int bodyId) override;

--- a/Razor/src/Razor/Physics/JoltPhysics/JoltPhysicsEngine.h
+++ b/Razor/src/Razor/Physics/JoltPhysics/JoltPhysicsEngine.h
@@ -84,6 +84,8 @@ namespace Razor
 
 		std::vector<ContactInfo> GetContactInfo(unsigned int bodyId);
 
+		void ClearContactMap();
+
 	private:
 		std::unordered_map<JPH::BodyID, std::vector<ContactInfo>> _mBodyContactMap;
 		std::mutex _mBodyContactMapMutex {};
@@ -106,10 +108,11 @@ namespace Razor
 		void Simulate(float deltaTime) override;
 		Vector3 GetPosition(unsigned int bodyId) const override;
 		void ApplyLinearVelocity(unsigned int bodyId, const Vector3& velocity) override;
-		unsigned int CreateBoxRigidBody(Vector3 position, float mass, EPhysicsMotionType motionType, bool bIsStatic) override;
+		unsigned int CreateBoxRigidBody(Vector3 position, float mass, EPhysicsMotionType motionType, bool bIsStatic, bool bIsTrigger) override;
 		void SetGravity(unsigned int bodyId, bool useGravity) override;
 		void DestroyBody(unsigned int bodyId) override;
 		std::vector<ContactInfo> GetContactInfo(unsigned int bodyId) override;
+		void MoveKinematic(unsigned int bodyId, Vector3 position, float deltaTime) override;
 
 	private:
 		JPH::PhysicsSystem _mPhysicsSystem;

--- a/Razor/src/Razor/Scene/Scene.cpp
+++ b/Razor/src/Razor/Scene/Scene.cpp
@@ -9,6 +9,7 @@
 #include "../Utils/Vector.h"
 #include "../Physics/Components/BoxBody.h"
 #include "../Physics/IPhysicsEngine.h"
+#include "../Renderer/Font/Text.h"
 
 namespace
 {
@@ -53,6 +54,7 @@ namespace Razor
 		CopyComponent<BoxBody>         (registry, copy->registry, entityMap);
 		CopyComponent<Input>           (registry, copy->registry, entityMap);
 		CopyComponent<CollisionComponent>           (registry, copy->registry, entityMap);
+		CopyComponent<Text>           (registry, copy->registry, entityMap);
 
 		return copy;
 	}

--- a/Razor/src/Razor/Scene/Scene.cpp
+++ b/Razor/src/Razor/Scene/Scene.cpp
@@ -119,6 +119,7 @@ namespace Razor
 		{
 			Transform& transform = GetEntity(entity)->GetComponent<Transform>();
 			Vector3 pos = { transform.Position.x, transform.Position.y, transform.Position.z };
+			Vector3 scale = { transform.Scale.x, transform.Scale.y, transform.Scale.z };
 			BoxBody& body = GetEntity(entity)->GetComponent<BoxBody>();
 			body.OnCollisionStarted = []() { RZ_CORE_INFO("Collision started"); };
 			bool bIsTrigger = false;
@@ -126,7 +127,7 @@ namespace Razor
 			{
 				bIsTrigger = GetEntity(entity)->GetComponent<CollisionComponent>().bIsTrigger;
 			}
-			body.bodyId = Engine::Get().GetPhysicsEngine().CreateBoxRigidBody(pos, body.mMass, body.mMotionType, body.mbIsStatic, bIsTrigger);
+			body.bodyId = Engine::Get().GetPhysicsEngine().CreateBoxRigidBody(pos, scale, body.mMass, body.mMotionType, body.mbIsStatic, bIsTrigger);
 			
 			if (body.bodyId == 0xFFFFFFFF)
 			{

--- a/Razor/src/Razor/Scene/Scene.cpp
+++ b/Razor/src/Razor/Scene/Scene.cpp
@@ -52,6 +52,7 @@ namespace Razor
 		CopyComponent<Collider>        (registry, copy->registry, entityMap);
 		CopyComponent<BoxBody>         (registry, copy->registry, entityMap);
 		CopyComponent<Input>           (registry, copy->registry, entityMap);
+		CopyComponent<CollisionComponent>           (registry, copy->registry, entityMap);
 
 		return copy;
 	}
@@ -118,7 +119,13 @@ namespace Razor
 			Vector3 pos = { transform.Position.x, transform.Position.y, transform.Position.z };
 			BoxBody& body = GetEntity(entity)->GetComponent<BoxBody>();
 			body.OnCollisionStarted = []() { RZ_CORE_INFO("Collision started"); };
-			body.bodyId = Engine::Get().GetPhysicsEngine().CreateBoxRigidBody(pos, body.mMass, body.mMotionType, body.mbIsStatic);
+			bool bIsTrigger = false;
+			if(GetEntity(entity)->HasComponent<CollisionComponent>())
+			{
+				bIsTrigger = GetEntity(entity)->GetComponent<CollisionComponent>().bIsTrigger;
+			}
+			body.bodyId = Engine::Get().GetPhysicsEngine().CreateBoxRigidBody(pos, body.mMass, body.mMotionType, body.mbIsStatic, bIsTrigger);
+			
 			if (body.bodyId == 0xFFFFFFFF)
 			{
 				RZ_CORE_ERROR("Scene(StartScene): -> Failed to create BoxBody physics body for entity");

--- a/Razor/src/Razor/Scene/SceneSerializer.cpp
+++ b/Razor/src/Razor/Scene/SceneSerializer.cpp
@@ -181,8 +181,11 @@ namespace Razor
 		}
 		if (InEntity.HasComponent<CollisionComponent>())
 		{
+			CollisionComponent& comp = InEntity.GetComponent<CollisionComponent>();
 			yaml_emitter_key(Out, "CollisionComponent");
 			yaml_emitter_begin_map(Out);
+			yaml_emitter_key(Out, "Trigger");
+			yaml_emitter_value_bool(Out, comp.bIsTrigger);
 			yaml_emitter_end_map(Out);
 		}
 		if (InEntity.HasComponent<Text>())
@@ -447,8 +450,13 @@ namespace Razor
 			Camera camera;
 			DeserializedEntity->AddComponent<Camera>(camera);
 		}
-		if (yaml_get_child(EntityNode, "CollisionComponent"))
-			DeserializedEntity->AddComponent<CollisionComponent>();
+		auto CollisionComponent = yaml_get_child(EntityNode, "CollisionComponent");
+		if (CollisionComponent)
+		{
+			Razor::CollisionComponent comp;
+			comp.bIsTrigger = yaml_as_bool(yaml_get_child(CollisionComponent, "Trigger"), false);
+			DeserializedEntity->AddComponent<Razor::CollisionComponent>(comp);
+		}
 		auto TextComponent = yaml_get_child(EntityNode, "Text");
 		if (TextComponent)
 		{

--- a/Razor/src/Razor/Scripting/ScriptClass.cpp
+++ b/Razor/src/Razor/Scripting/ScriptClass.cpp
@@ -23,7 +23,7 @@ namespace Razor
 		if (Type == "System.String")  return ScriptFieldType::String;
 		if (Type == "System.Byte")    return ScriptFieldType::Byte;
 		if (Type == "System.Short")   return ScriptFieldType::Short;
-		if (Type == "System.Int")     return ScriptFieldType::Int;
+		if (Type == "System.Int32")   return ScriptFieldType::Int;
 		if (Type == "System.Long")    return ScriptFieldType::Long;
 		if (Type == "System.UByte")   return ScriptFieldType::UByte;
 		if (Type == "System.UShort")  return ScriptFieldType::UShort;

--- a/Razor/src/Razor/Scripting/ScriptClass.cpp
+++ b/Razor/src/Razor/Scripting/ScriptClass.cpp
@@ -16,7 +16,7 @@ namespace Razor
 	ScriptFieldType ScriptField::GetType() const
 	{
 		if (Type == "None")    return ScriptFieldType::None;
-		if (Type == "System.Float")   return ScriptFieldType::Float;
+		if (Type == "System.Single")   return ScriptFieldType::Float;
 		if (Type == "System.Double")  return ScriptFieldType::Double;
 		if (Type == "System.Bool")    return ScriptFieldType::Bool;
 		if (Type == "System.Char")    return ScriptFieldType::Char;
@@ -34,7 +34,7 @@ namespace Razor
 		if (Type == "System.Vector4") return ScriptFieldType::Vector4;
 		if (Type == "Razor.Entity")  return ScriptFieldType::Entity;
 
-		RZ_CORE_ERROR("ScriptField::GetType() -> Unknown ScriptFieldType");
+		RZ_CORE_ERROR("ScriptField::GetType() -> Unknown ScriptFieldType {0}", Type);
 		return ScriptFieldType::None;
 	}
 }

--- a/Razor/src/Razor/Scripting/ScriptGlue.cpp
+++ b/Razor/src/Razor/Scripting/ScriptGlue.cpp
@@ -8,6 +8,7 @@
 #include "ScriptClass.h"
 #include "ScriptInterface.h"
 #include "../IO/RazorIO.h"
+#include "../Renderer/Font/Text.h"
 
 #if defined(_MSC_VER)
     #define RAZOR_CALL __cdecl
@@ -140,6 +141,47 @@ extern "C"
 		*outOtherId = events[index].OtherEntityId;
 	}
 
+	 static void RAZOR_CALL Text_SetText(uint32_t entityId, const char* text)
+ 	{
+ 	    Ref<Entity> entity = Engine::Get().CurrentScene->GetEntity(static_cast<entt::entity>(entityId));
+ 	    if (!entity || !entity->HasComponent<Text>()) return;
+ 	    entity->GetComponent<Text>().SetText(text);
+ 	}
+
+ 	static void RAZOR_CALL Text_GetText(uint32_t entityId, char* buffer, int bufferSize)
+ 	{
+ 	    Ref<Entity> entity = Engine::Get().CurrentScene->GetEntity(static_cast<entt::entity>(entityId));
+ 	    if (!entity || !entity->HasComponent<Text>()) return;
+ 	    const std::string& txt = entity->GetComponent<Text>().GetText();
+ 	    strncpy(buffer, txt.c_str(), bufferSize - 1);
+ 	    buffer[bufferSize - 1] = '\0';
+ 	}
+
+ 	static void RAZOR_CALL Text_SetColor(uint32_t entityId, float r, float g, float b)
+ 	{
+ 	    Ref<Entity> entity = Engine::Get().CurrentScene->GetEntity(static_cast<entt::entity>(entityId));
+ 	    if (!entity || !entity->HasComponent<Text>()) return;
+ 	    entity->GetComponent<Text>().mColor = Vector3(r, g, b);
+ 	}
+
+ 	static void RAZOR_CALL Text_SetScale(uint32_t entityId, float scale)
+ 	{
+ 	    Ref<Entity> entity = Engine::Get().CurrentScene->GetEntity(static_cast<entt::entity>(entityId));
+ 	    if (!entity || !entity->HasComponent<Text>()) return;
+ 	    entity->GetComponent<Text>().mScale = scale;
+ 	}
+
+ 	static void* Scene_GetEntitiesWithText(int* count)
+ 	{
+ 	    static std::vector<uint32_t> ids;
+ 	    ids.clear();
+ 	    auto entities = Engine::Get().CurrentScene->GetEntitiesWithComponents<Text>();
+ 	    for (const entt::entity& e : entities)
+ 	        ids.push_back(static_cast<uint32_t>(e));
+ 	    *count = static_cast<int>(ids.size());
+ 	    return ids.data();
+ 	}
+
 	void ScriptGlue::RegisterFunctions(Ref<Coral::ManagedAssembly> Assembly)
 	{
 		Assembly->AddInternalCall("Razor.InternalCalls", "Entity_HasComponent", (void*)Entity_HasComponent);
@@ -153,6 +195,11 @@ extern "C"
 		Assembly->AddInternalCall("Razor.InternalCalls", "Transform_SetPosition",    (void*)Transform_SetPosition);
 		Assembly->AddInternalCall("Razor.InternalCalls", "Collision_GetEventCount", (void*)Collision_GetEventCount);
 		Assembly->AddInternalCall("Razor.InternalCalls", "Collision_GetEvent",      (void*)Collision_GetEvent);
+		Assembly->AddInternalCall("Razor.InternalCalls", "Text_SetText",              (void*)Text_SetText);
+ 		Assembly->AddInternalCall("Razor.InternalCalls", "Text_GetText",              (void*)Text_GetText);
+ 		Assembly->AddInternalCall("Razor.InternalCalls", "Text_SetColor",             (void*)Text_SetColor);
+ 		Assembly->AddInternalCall("Razor.InternalCalls", "Text_SetScale",             (void*)Text_SetScale);
+ 		Assembly->AddInternalCall("Razor.InternalCalls", "Scene_GetEntitiesWithText", (void*)Scene_GetEntitiesWithText);
 
 		Assembly->UploadInternalCalls();
 	}

--- a/Razor/src/Razor/Scripting/ScriptGlue.cpp
+++ b/Razor/src/Razor/Scripting/ScriptGlue.cpp
@@ -131,7 +131,7 @@ extern "C"
 		return static_cast<int>(entity->GetComponent<CollisionComponent>().Events.size());
 	}
 
-	static void RAZOR_CALL Collision_GetEvent(uint32_t entityId, int index, int* outType, uint32_t* outOtherId)
+	static void RAZOR_CALL Collision_GetEvent(uint32_t entityId, int index, int* outType, uint32_t* outOtherId, float** outHitX, float** outHitY, float** outHitZ, int* hitLen)
 	{
 		Ref<Entity> entity = Engine::Get().CurrentScene->GetEntity(static_cast<entt::entity>(entityId));
 		if (!entity || !entity->HasComponent<CollisionComponent>()) return;
@@ -139,6 +139,22 @@ extern "C"
 		if (index < 0 || index >= static_cast<int>(events.size())) return;
 		*outType    = static_cast<int>(events[index].Type);
 		*outOtherId = events[index].OtherEntityId;
+		static std::vector<float> x;
+		static std::vector<float> y;
+		static std::vector<float> z;
+
+		*hitLen = events[index].mCollisionPoints.size();
+
+		for(int i = 0; i < *hitLen; i++)
+		{
+			Vector3 pos = events[index].mCollisionPoints[i];
+			x.push_back(pos.X);
+			y.push_back(pos.Y);
+			z.push_back(pos.Z);
+		}
+		*outHitX = &x[0];
+		*outHitY = &y[0];
+		*outHitZ = &z[0];
 	}
 
 	 static void RAZOR_CALL Text_SetText(uint32_t entityId, const char* text)

--- a/Razor/src/Razor/Systems/CollisionSystem.cpp
+++ b/Razor/src/Razor/Systems/CollisionSystem.cpp
@@ -41,7 +41,7 @@ namespace Razor
 						uint32_t otherId = UINT32_MAX;
 						auto it = bodyToEntity.find(contact.mOtherBodyId);
 						if (it != bodyToEntity.end()) otherId = it->second;
-						collComp->Events.push_back({ CollisionEventType::Started, otherId });
+						collComp->Events.push_back({ CollisionEventType::Started, otherId, contact.mCollisionPoints });
 					}
 				}
 				else if (contact.mContactType == EContactType::Ended && collComp)
@@ -49,7 +49,7 @@ namespace Razor
 					uint32_t otherId = UINT32_MAX;
 					auto it = bodyToEntity.find(contact.mOtherBodyId);
 					if (it != bodyToEntity.end()) otherId = it->second;
-					collComp->Events.push_back({ CollisionEventType::Ended, otherId });
+					collComp->Events.push_back({ CollisionEventType::Ended, otherId, contact.mCollisionPoints });
 				}
 			}
 		}

--- a/Razor/src/Razor/Systems/CollisionSystem.cpp
+++ b/Razor/src/Razor/Systems/CollisionSystem.cpp
@@ -14,6 +14,7 @@ namespace Razor
 		for (auto entity : CurrentScene->GetEntitiesWithComponents<BoxBody>())
 		{
 			BoxBody& body = CurrentScene->GetComponent<BoxBody>(entity);
+			// TODO what happens if an entity is destroyed?
 			bodyToEntity[body.bodyId] = static_cast<uint32_t>(entity);
 		}
 
@@ -30,7 +31,7 @@ namespace Razor
 			std::vector<ContactInfo> contacts = physics.GetContactInfo(body.bodyId);
 			for (const ContactInfo& contact : contacts)
 			{
-				if (contact.mContactType == EContactType::Started)
+				if (contact.mContactType == EContactType::Started && !contact.mContactProcessed)
 				{
 					if (body.OnCollisionStarted)
 						body.OnCollisionStarted();

--- a/Razor/src/Razor/Systems/PhysicsSystem.cpp
+++ b/Razor/src/Razor/Systems/PhysicsSystem.cpp
@@ -10,12 +10,20 @@ namespace Razor
 	{
 		for (auto entity : CurrentScene->GetEntitiesWithComponents<BoxBody, Transform>())
 		{
+			
 			BoxBody& body = CurrentScene->GetComponent<BoxBody>(entity);
 			Transform& transform = CurrentScene->GetComponent<Transform>(entity);
-
 			Vector3 physicsPos = Engine::Get().GetPhysicsEngine().GetPosition(body.bodyId);
-			// TODO this may result in some snappy movements may need to use some smoothing here
-			transform.Position = { physicsPos.X, physicsPos.Y, physicsPos.Z };
+			if(body.mMotionType != EPhysicsMotionType::Kinematic)
+			{
+				// TODO this may result in some snappy movements may need to use some smoothing here
+				transform.Position = { physicsPos.X, physicsPos.Y, physicsPos.Z };
+			}
+			else
+			{
+				const float fixedStep = 1.0f / 60.0f;
+				Engine::Get().GetPhysicsEngine().MoveKinematic(body.bodyId, {transform.Position.x, transform.Position.y, transform.Position.z}, fixedStep);
+			}
 		}
 	}
 }

--- a/Razor/src/Razor/Systems/RSRenderPass.cpp
+++ b/Razor/src/Razor/Systems/RSRenderPass.cpp
@@ -48,7 +48,7 @@ namespace Razor
 			if(!Font)
 			{
 				RZ_CORE_WARN("No font for font key on text object");
-				return;
+				continue;
 			}
 			// TODO probably should also rely on a material
 			Renderer->UseShader(EntityText.mShader.ID);

--- a/Sandbox/Sandbox.proj
+++ b/Sandbox/Sandbox.proj
@@ -1,4 +1,4 @@
 ProjectName: Sandbox
 AssetDirectory: assets
-DllDirectory: Scripts/Binaries/net9.0
+DllDirectory: Scripts/Binaries/net9.0/net9.0
 MainScenePath: /assets/scenes/Main.rzscn

--- a/Sandbox/Scripts/Sandbox.csproj
+++ b/Sandbox/Scripts/Sandbox.csproj
@@ -50,6 +50,8 @@
   <ItemGroup>
     <Compile Include="Source\Player.cs" />
     <Compile Include="Source\PlayerMovement.cs" />
+    <Compile Include="Source\Score.cs" />
+    <Compile Include="Source\ScoreSystem.cs" />
     <Compile Include="Source\TestBox.cs" />
     <Compile Include="Source\TestBoxBodySystem.cs" />
   </ItemGroup>

--- a/Sandbox/Scripts/Source/Player.cs
+++ b/Sandbox/Scripts/Source/Player.cs
@@ -10,6 +10,9 @@ namespace Sandbox
     public class Player : Razor.Component
     {
         public string Name;
+        public float BaseSpeed = 5.0f;
         public int Direction;
+
+        public float YDirection;
     }
 }

--- a/Sandbox/Scripts/Source/Player.cs
+++ b/Sandbox/Scripts/Source/Player.cs
@@ -10,5 +10,6 @@ namespace Sandbox
     public class Player : Razor.Component
     {
         public string Name;
+        public int Direction;
     }
 }

--- a/Sandbox/Scripts/Source/PlayerMovement.cs
+++ b/Sandbox/Scripts/Source/PlayerMovement.cs
@@ -17,12 +17,18 @@ namespace Sandbox
             {
                 Player player = Scene.GetComponent<Player>(id);
                 if (player == null) continue;
-                logger.Print("Player Name is: " + player.Name);
+
+                foreach (CollisionEvent colEvent in Collision.GetEvents(id))
+                {
+                    if(colEvent.Type == CollisionEventType.Started)
+                    {
+                        logger.Print("Collided with entity: " + colEvent.OtherEntityId);
+                        player.Direction *= -1;
+                    }
+                }
+
                 var pos = Transform.GetPosition(id);
-                if (Input.IsKeyPressed(RazorKey.W))
-                    Transform.SetPosition(id, pos.X, pos.Y, pos.Z + 5.0f * deltaTime);
-                if (Input.IsKeyPressed(RazorKey.S))
-                    Transform.SetPosition(id, pos.X, pos.Y, pos.Z - 5.0f * deltaTime);
+                Transform.SetPosition(id, pos.X + (5.0f * player.Direction * deltaTime), pos.Y, pos.Z);
             }
         }
     }

--- a/Sandbox/Scripts/Source/PlayerMovement.cs
+++ b/Sandbox/Scripts/Source/PlayerMovement.cs
@@ -15,20 +15,46 @@ namespace Sandbox
             Log logger = new Log();
             foreach (uint id in entities)
             {
-                Player player = Scene.GetComponent<Player>(id);
+                Player player = Scene.GetScriptComponent<Player>(id);
                 if (player == null) continue;
+                var pos = Transform.GetPosition(id);
+
+                if (pos.X < -20.0f )
+                {
+                   IncrementScore(0);
+                   Transform.SetPosition(id, 0, 0, pos.Z);
+                   return;
+                }
+                else if (pos.X > 20.0f)
+                {
+                    IncrementScore(1);
+                    Transform.SetPosition(id, 0, 0, pos.Z);
+                    return;
+                }
 
                 foreach (CollisionEvent colEvent in Collision.GetEvents(id))
                 {
                     if(colEvent.Type == CollisionEventType.Started)
                     {
-                        logger.Print("Collided with entity: " + colEvent.OtherEntityId);
                         player.Direction *= -1;
                     }
                 }
-
-                var pos = Transform.GetPosition(id);
+                
                 Transform.SetPosition(id, pos.X + (5.0f * player.Direction * deltaTime), pos.Y, pos.Z);
+            }
+        }
+
+        private void IncrementScore(int index)
+        {
+             // We need to get the score component and increment it 
+            var scoreEntities = Scene.GetEntitiesWithScriptComponent<Score>();
+            foreach (uint scoreEntity in scoreEntities) 
+            {
+                Score score = Scene.GetScriptComponent<Score>(scoreEntity);
+                if (score.playerIndex == index)
+                {
+                    score.score += 1;
+                }
             }
         }
     }

--- a/Sandbox/Scripts/Source/PlayerMovement.cs
+++ b/Sandbox/Scripts/Source/PlayerMovement.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO.Pipelines;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
 using Razor;
 
 namespace Sandbox
@@ -19,13 +21,15 @@ namespace Sandbox
                 if (player == null) continue;
                 var pos = Transform.GetPosition(id);
 
-                if (pos.X < -20.0f )
+                if (pos.X < -15.0f )
                 {
                    IncrementScore(0);
                    Transform.SetPosition(id, 0, 0, pos.Z);
+                   player.YDirection = 0.0f;
+                   player.BaseSpeed = 5.0f;
                    return;
                 }
-                else if (pos.X > 20.0f)
+                else if (pos.X > 15.0f)
                 {
                     IncrementScore(1);
                     Transform.SetPosition(id, 0, 0, pos.Z);
@@ -37,10 +41,30 @@ namespace Sandbox
                     if(colEvent.Type == CollisionEventType.Started)
                     {
                         player.Direction *= -1;
+                        player.BaseSpeed += 0.25f;
+                        var otherPos = Transform.GetPosition(colEvent.OtherEntityId);
+                        if (otherPos.Y - 0.1f > pos.Y)
+                        {
+                            player.YDirection = -0.5f;
+                        }
+                        else if (otherPos.Y + 0.1f < pos.Y)
+                        {
+                            player.YDirection = 0.5f;
+                        }
+                        else
+                        {
+                            player.YDirection = 0.0f;
+                        }
+                        
                     }
                 }
                 
-                Transform.SetPosition(id, pos.X + (5.0f * player.Direction * deltaTime), pos.Y, pos.Z);
+                if (pos.Y > 11.0f || pos.Y < -11.0f)
+                {
+                    player.YDirection *= -1;
+                }
+
+                Transform.SetPosition(id, pos.X + (player.BaseSpeed * player.Direction * deltaTime), pos.Y + (player.BaseSpeed * player.YDirection * deltaTime), pos.Z);
             }
         }
 

--- a/Sandbox/Scripts/Source/Score.cs
+++ b/Sandbox/Scripts/Source/Score.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -7,9 +7,9 @@ using Razor;
 
 namespace Sandbox
 {
-    public class TestBox : Razor.Component
+    public class Score : Razor.Component
     {
-        public string Name;
-        public int PlayerIndex;
+        public int playerIndex;
+        public int score;
     }
 }

--- a/Sandbox/Scripts/Source/ScoreSystem.cs
+++ b/Sandbox/Scripts/Source/ScoreSystem.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Razor;
+
+namespace Sandbox
+{
+    public class ScoreSystem : Razor.System
+    {
+        public override void Run(float deltaTime)
+        {
+            var entities = Scene.GetEntitiesWithScriptComponent<Score>();
+            Log logger = new Log();
+            foreach (uint id in entities)
+            {
+                Score score = Scene.GetScriptComponent<Score>(id);
+                Text text = Scene.GetNativeComponent<Text>(id);
+                if (score == null || text == null) continue;
+                var pos = Transform.GetPosition(id);
+
+                text.SetText(score.score.ToString());
+            }
+        }
+    }
+}

--- a/Sandbox/Scripts/Source/TestBoxBodySystem.cs
+++ b/Sandbox/Scripts/Source/TestBoxBodySystem.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks.Dataflow;
+using System;
 using Razor;
 
 namespace Sandbox
@@ -16,16 +17,16 @@ namespace Sandbox
                 if(box.PlayerIndex == 0)
                 {
                     if (Input.IsKeyPressed(RazorKey.W))
-                        Transform.SetPosition(id, pos.X, pos.Y + 5.0f * deltaTime, pos.Z);
+                        Transform.SetPosition(id, pos.X, Math.Clamp(pos.Y + 5.0f * deltaTime, -7.0f, 7.0f), pos.Z);
                     if (Input.IsKeyPressed(RazorKey.S))
-                        Transform.SetPosition(id, pos.X, pos.Y - 5.0f * deltaTime, pos.Z);
+                        Transform.SetPosition(id, pos.X, Math.Clamp(pos.Y - 5.0f * deltaTime, -7.0f, 7.0f), pos.Z);
                 }
                 else
                 {
                     if (Input.IsKeyPressed(RazorKey.A))
-                        Transform.SetPosition(id, pos.X, pos.Y + 5.0f * deltaTime, pos.Z);
+                        Transform.SetPosition(id, pos.X, Math.Clamp(pos.Y + 5.0f * deltaTime, -7.0f, 7.0f), pos.Z);
                     if (Input.IsKeyPressed(RazorKey.D))
-                        Transform.SetPosition(id, pos.X, pos.Y - 5.0f * deltaTime, pos.Z);
+                        Transform.SetPosition(id, pos.X, Math.Clamp(pos.Y - 5.0f * deltaTime, -7.0f, 7.0f), pos.Z);
                 }
             }
         }

--- a/Sandbox/Scripts/Source/TestBoxBodySystem.cs
+++ b/Sandbox/Scripts/Source/TestBoxBodySystem.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks.Dataflow;
 using Razor;
 
 namespace Sandbox
@@ -8,11 +9,23 @@ namespace Sandbox
         {
             var entities = Scene.GetEntitiesWithScriptComponent<TestBox>();
             Log logger = new Log();
-            foreach (uint id in entities)
+            foreach(uint id in entities)
             {
-                foreach (CollisionEvent colEvent in Collision.GetEvents(id))
+                var pos = Transform.GetPosition(id);
+                TestBox box = Scene.GetScriptComponent<TestBox>(id);
+                if(box.PlayerIndex == 0)
                 {
-                    logger.Print("Collided with entity: " + colEvent.OtherEntityId);
+                    if (Input.IsKeyPressed(RazorKey.W))
+                        Transform.SetPosition(id, pos.X, pos.Y + 5.0f * deltaTime, pos.Z);
+                    if (Input.IsKeyPressed(RazorKey.S))
+                        Transform.SetPosition(id, pos.X, pos.Y - 5.0f * deltaTime, pos.Z);
+                }
+                else
+                {
+                    if (Input.IsKeyPressed(RazorKey.A))
+                        Transform.SetPosition(id, pos.X, pos.Y + 5.0f * deltaTime, pos.Z);
+                    if (Input.IsKeyPressed(RazorKey.D))
+                        Transform.SetPosition(id, pos.X, pos.Y - 5.0f * deltaTime, pos.Z);
                 }
             }
         }

--- a/Sandbox/Scripts/premake5.lua
+++ b/Sandbox/Scripts/premake5.lua
@@ -24,7 +24,7 @@ project "Sandbox"
         prebuildcommands {
             'dotnet build "%{prj.location}/Sandbox.csproj"' ..
             ' -c %{cfg.buildcfg}' ..
-            ' -o "%{prj.location}/Binaries/net9.0"' ..
+            ' -o "%{prj.location}/Binaries"' ..
             ' --nologo'
         }
 

--- a/Sandbox/assets/scenes/Main.rzscn
+++ b/Sandbox/assets/scenes/Main.rzscn
@@ -7,10 +7,6 @@ Entities:
       Scale: [0, 0, 0]
     ScriptComponent:
       []
-    Text:
-      Text: Pong Reborn
-      Font: fonts/Roboto-Light.ttf
-      Color: [0.852941155, 0.196510956, 0.196510956]
   - Entity: 4
     Transform:
       Position: [0, 0, 35]
@@ -22,7 +18,7 @@ Entities:
       {}
   - Entity: 3
     Transform:
-      Position: [5, 0, 5.28765678]
+      Position: [0, 0, 0]
       Rotation: [0, 0, 0]
       Scale: [0, 0, 0]
     Mesh:
@@ -30,12 +26,22 @@ Entities:
     ScriptComponent:
       - Sandbox.Player:
           ScriptFields:
+            - Direction:
+                Type: System.Int
+                Data: 1
             - Name:
                 Type: System.String
                 Data: Joe
+    BoxBody:
+      UseGravity: false
+      IsStatic: false
+      MotionType: Kinematic
+      Mass: 1
+    CollisionComponent:
+      Trigger: true
   - Entity: 2
     Transform:
-      Position: [-2.51499678e-05, 1.98950827, -4.45543674e-06]
+      Position: [-10, 0, 0]
       Rotation: [0, 0, 0]
       Scale: [0, 0, 0]
     Mesh:
@@ -47,10 +53,12 @@ Entities:
                 Type: System.String
                 Data: ""
     BoxBody:
-      UseGravity: true
+      UseGravity: false
       IsStatic: false
       MotionType: Dynamic
       Mass: 1
+    CollisionComponent:
+      Trigger: true
   - Entity: 1
     Transform:
       Position: [1, 0, -10]
@@ -65,7 +73,7 @@ Entities:
       []
   - Entity: 0
     Transform:
-      Position: [0, 0, 0]
+      Position: [10, 0, 0]
       Rotation: [0, 0, 0]
       Scale: [0, 0, 0]
     Mesh:
@@ -74,9 +82,11 @@ Entities:
       []
     BoxBody:
       UseGravity: false
-      IsStatic: true
-      MotionType: Static
-      Mass: 1
+      IsStatic: false
+      MotionType: Dynamic
+      Mass: 10000
+    CollisionComponent:
+      Trigger: true
 Systems:
   - Sandbox.PlayerMovement
   - Sandbox.TestBoxBodySystem

--- a/Sandbox/assets/scenes/Main.rzscn
+++ b/Sandbox/assets/scenes/Main.rzscn
@@ -2,15 +2,15 @@ Scene: Untitled
 Entities:
   - Entity: 6
     Transform:
-      Position: [700, 700, 0]
+      Position: [900, 700, 0]
       Rotation: [0, 0, 0]
-      Scale: [0, 0, 0]
+      Scale: [1, 1, 1]
     ScriptComponent:
       - Sandbox.Score:
           ScriptFields:
             - playerIndex:
                 Type: System.Int
-                Data: 0
+                Data: 1
             - score:
                 Type: System.Int
                 Data: 0
@@ -20,39 +20,42 @@ Entities:
       Color: [1, 1, 1]
   - Entity: 5
     Transform:
-      Position: [0, 0, 35]
+      Position: [15, 0, 0]
       Rotation: [0, 0, 0]
-      Scale: [0, 0, 0]
-    Camera:
-      {}
-  - Entity: 4
-    Transform:
-      Position: [0, 0, 0]
-      Rotation: [0, 0, 0]
-      Scale: [0, 0, 0]
+      Scale: [1, 5, 1]
     Mesh:
       ModelKey: models/Cube.model
     ScriptComponent:
-      - Sandbox.Player:
+      - Sandbox.TestBox:
           ScriptFields:
-            - Direction:
-                Type: System.Int
-                Data: 1
             - Name:
                 Type: System.String
-                Data: Joe
+                Data: ""
+            - PlayerIndex:
+                Type: System.Int
+                Data: 1
     BoxBody:
       UseGravity: false
       IsStatic: false
       MotionType: Kinematic
-      Mass: 1
+      Mass: 10000
     CollisionComponent:
       Trigger: true
+  - Entity: 4
+    Transform:
+      Position: [1, 0, -10]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    DirectionalLight:
+      Diffuse: [1, 1, 1]
+      Ambient: [1, 1, 1]
+      Specular: [1, 1, 1]
+      Direction: [1, 0, 0]
   - Entity: 3
     Transform:
-      Position: [-10, 0, 0]
+      Position: [-15, 0, 0]
       Rotation: [0, 0, 0]
-      Scale: [0, 0, 0]
+      Scale: [1, 5, 1]
     Mesh:
       ModelKey: models/Cube.model
     ScriptComponent:
@@ -73,48 +76,53 @@ Entities:
       Trigger: true
   - Entity: 2
     Transform:
-      Position: [1, 0, -10]
+      Position: [0, 0, 0]
       Rotation: [0, 0, 0]
-      Scale: [0, 0, 0]
-    DirectionalLight:
-      Diffuse: [1, 1, 1]
-      Ambient: [1, 1, 1]
-      Specular: [1, 1, 1]
-      Direction: [1, 0, 0]
-  - Entity: 1
-    Transform:
-      Position: [10, 0, 0]
-      Rotation: [0, 0, 0]
-      Scale: [0, 0, 0]
+      Scale: [1, 1, 1]
     Mesh:
       ModelKey: models/Cube.model
     ScriptComponent:
-      - Sandbox.TestBox:
+      - Sandbox.Player:
           ScriptFields:
-            - Name:
-                Type: System.String
-                Data: ""
-            - PlayerIndex:
+            - BaseSpeed:
+                Type: System.Float
+                Data: 5
+            - Direction:
                 Type: System.Int
                 Data: 1
+            - Name:
+                Type: System.String
+                Data: Joe
+            - YDirection:
+                Type: System.Float
+                Data: 0
     BoxBody:
       UseGravity: false
       IsStatic: false
       MotionType: Kinematic
-      Mass: 10000
+      Mass: 1
     CollisionComponent:
       Trigger: true
+  - Entity: 1
+    Transform:
+      Position: [0, 0, 30]
+      Rotation: [0, 0, 0]
+      Scale: [1, 1, 1]
+    ScriptComponent:
+      []
+    Camera:
+      {}
   - Entity: 0
     Transform:
-      Position: [900, 700, 0]
+      Position: [700, 700, 0]
       Rotation: [0, 0, 0]
-      Scale: [0, 0, 0]
+      Scale: [1, 1, 1]
     ScriptComponent:
       - Sandbox.Score:
           ScriptFields:
             - playerIndex:
                 Type: System.Int
-                Data: 1
+                Data: 0
             - score:
                 Type: System.Int
                 Data: 0

--- a/Sandbox/assets/scenes/Main.rzscn
+++ b/Sandbox/assets/scenes/Main.rzscn
@@ -2,7 +2,7 @@ Scene: Untitled
 Entities:
   - Entity: 6
     Transform:
-      Position: [900, 700, 0]
+      Position: [700, 700, 0]
       Rotation: [0, 0, 0]
       Scale: [0, 0, 0]
     ScriptComponent:
@@ -10,45 +10,44 @@ Entities:
           ScriptFields:
             - playerIndex:
                 Type: System.Int
-                Data: 1
+                Data: 0
             - score:
                 Type: System.Int
                 Data: 0
+    Text:
+      Text: 0
+      Font: fonts/Roboto-Light.ttf
+      Color: [1, 1, 1]
   - Entity: 5
     Transform:
-      Position: [10, 0, 0]
+      Position: [0, 0, 35]
+      Rotation: [0, 0, 0]
+      Scale: [0, 0, 0]
+    Camera:
+      {}
+  - Entity: 4
+    Transform:
+      Position: [0, 0, 0]
       Rotation: [0, 0, 0]
       Scale: [0, 0, 0]
     Mesh:
       ModelKey: models/Cube.model
     ScriptComponent:
-      - Sandbox.TestBox:
+      - Sandbox.Player:
           ScriptFields:
-            - Name:
-                Type: System.String
-                Data: ""
-            - PlayerIndex:
+            - Direction:
                 Type: System.Int
                 Data: 1
+            - Name:
+                Type: System.String
+                Data: Joe
     BoxBody:
       UseGravity: false
       IsStatic: false
       MotionType: Kinematic
-      Mass: 10000
+      Mass: 1
     CollisionComponent:
       Trigger: true
-  - Entity: 4
-    Transform:
-      Position: [1, 0, -10]
-      Rotation: [0, 0, 0]
-      Scale: [0, 0, 0]
-    DirectionalLight:
-      Diffuse: [1, 1, 1]
-      Ambient: [1, 1, 1]
-      Specular: [1, 1, 1]
-      Direction: [1, 0, 0]
-    ScriptComponent:
-      []
   - Entity: 3
     Transform:
       Position: [-10, 0, 0]
@@ -74,37 +73,40 @@ Entities:
       Trigger: true
   - Entity: 2
     Transform:
-      Position: [0, 0, 0]
+      Position: [1, 0, -10]
+      Rotation: [0, 0, 0]
+      Scale: [0, 0, 0]
+    DirectionalLight:
+      Diffuse: [1, 1, 1]
+      Ambient: [1, 1, 1]
+      Specular: [1, 1, 1]
+      Direction: [1, 0, 0]
+  - Entity: 1
+    Transform:
+      Position: [10, 0, 0]
       Rotation: [0, 0, 0]
       Scale: [0, 0, 0]
     Mesh:
       ModelKey: models/Cube.model
     ScriptComponent:
-      - Sandbox.Player:
+      - Sandbox.TestBox:
           ScriptFields:
-            - Direction:
-                Type: System.Int
-                Data: 1
             - Name:
                 Type: System.String
-                Data: Joe
+                Data: ""
+            - PlayerIndex:
+                Type: System.Int
+                Data: 1
     BoxBody:
       UseGravity: false
       IsStatic: false
       MotionType: Kinematic
-      Mass: 1
+      Mass: 10000
     CollisionComponent:
       Trigger: true
-  - Entity: 1
-    Transform:
-      Position: [0, 0, 35]
-      Rotation: [0, 0, 0]
-      Scale: [0, 0, 0]
-    Camera:
-      {}
   - Entity: 0
     Transform:
-      Position: [700, 700, 0]
+      Position: [900, 700, 0]
       Rotation: [0, 0, 0]
       Scale: [0, 0, 0]
     ScriptComponent:
@@ -112,10 +114,14 @@ Entities:
           ScriptFields:
             - playerIndex:
                 Type: System.Int
-                Data: 0
+                Data: 1
             - score:
                 Type: System.Int
                 Data: 0
+    Text:
+      Text: 0
+      Font: fonts/Roboto-Light.ttf
+      Color: [1, 1, 1]
 Systems:
   - Sandbox.PlayerMovement
   - Sandbox.TestBoxBodySystem

--- a/Sandbox/assets/scenes/Main.rzscn
+++ b/Sandbox/assets/scenes/Main.rzscn
@@ -1,22 +1,78 @@
 Scene: Untitled
 Entities:
+  - Entity: 6
+    Transform:
+      Position: [900, 700, 0]
+      Rotation: [0, 0, 0]
+      Scale: [0, 0, 0]
+    ScriptComponent:
+      - Sandbox.Score:
+          ScriptFields:
+            - playerIndex:
+                Type: System.Int
+                Data: 1
+            - score:
+                Type: System.Int
+                Data: 0
   - Entity: 5
     Transform:
-      Position: [200, 700, 0]
+      Position: [10, 0, 0]
       Rotation: [0, 0, 0]
       Scale: [0, 0, 0]
+    Mesh:
+      ModelKey: models/Cube.model
     ScriptComponent:
-      []
+      - Sandbox.TestBox:
+          ScriptFields:
+            - Name:
+                Type: System.String
+                Data: ""
+            - PlayerIndex:
+                Type: System.Int
+                Data: 1
+    BoxBody:
+      UseGravity: false
+      IsStatic: false
+      MotionType: Kinematic
+      Mass: 10000
+    CollisionComponent:
+      Trigger: true
   - Entity: 4
     Transform:
-      Position: [0, 0, 35]
+      Position: [1, 0, -10]
       Rotation: [0, 0, 0]
       Scale: [0, 0, 0]
+    DirectionalLight:
+      Diffuse: [1, 1, 1]
+      Ambient: [1, 1, 1]
+      Specular: [1, 1, 1]
+      Direction: [1, 0, 0]
     ScriptComponent:
       []
-    Camera:
-      {}
   - Entity: 3
+    Transform:
+      Position: [-10, 0, 0]
+      Rotation: [0, 0, 0]
+      Scale: [0, 0, 0]
+    Mesh:
+      ModelKey: models/Cube.model
+    ScriptComponent:
+      - Sandbox.TestBox:
+          ScriptFields:
+            - Name:
+                Type: System.String
+                Data: ""
+            - PlayerIndex:
+                Type: System.Int
+                Data: 0
+    BoxBody:
+      UseGravity: false
+      IsStatic: false
+      MotionType: Kinematic
+      Mass: 1
+    CollisionComponent:
+      Trigger: true
+  - Entity: 2
     Transform:
       Position: [0, 0, 0]
       Rotation: [0, 0, 0]
@@ -39,54 +95,28 @@ Entities:
       Mass: 1
     CollisionComponent:
       Trigger: true
-  - Entity: 2
-    Transform:
-      Position: [-10, 0, 0]
-      Rotation: [0, 0, 0]
-      Scale: [0, 0, 0]
-    Mesh:
-      ModelKey: models/Cube.model
-    ScriptComponent:
-      - Sandbox.TestBox:
-          ScriptFields:
-            - Name:
-                Type: System.String
-                Data: ""
-    BoxBody:
-      UseGravity: false
-      IsStatic: false
-      MotionType: Dynamic
-      Mass: 1
-    CollisionComponent:
-      Trigger: true
   - Entity: 1
     Transform:
-      Position: [1, 0, -10]
+      Position: [0, 0, 35]
       Rotation: [0, 0, 0]
       Scale: [0, 0, 0]
-    DirectionalLight:
-      Diffuse: [1, 1, 1]
-      Ambient: [1, 1, 1]
-      Specular: [1, 1, 1]
-      Direction: [1, 0, 0]
-    ScriptComponent:
-      []
+    Camera:
+      {}
   - Entity: 0
     Transform:
-      Position: [10, 0, 0]
+      Position: [700, 700, 0]
       Rotation: [0, 0, 0]
       Scale: [0, 0, 0]
-    Mesh:
-      ModelKey: models/Cube.model
     ScriptComponent:
-      []
-    BoxBody:
-      UseGravity: false
-      IsStatic: false
-      MotionType: Dynamic
-      Mass: 10000
-    CollisionComponent:
-      Trigger: true
+      - Sandbox.Score:
+          ScriptFields:
+            - playerIndex:
+                Type: System.Int
+                Data: 0
+            - score:
+                Type: System.Int
+                Data: 0
 Systems:
   - Sandbox.PlayerMovement
   - Sandbox.TestBoxBodySystem
+  - Sandbox.ScoreSystem


### PR DESCRIPTION
## Description ##
This change is to implement a basic pong like game to demonstrate the current capabilities of the engine.

## Changes ##
### Editor ###
- Added UI for Transform components Scale & Rotation
- Added UI for removing components
- Added UI for Collision components Is Trigger
- Added check to AddScriptComponent to check of ScriptComponent is already present
- Added RemoveComponent to Entity to remove components from entities
- Added InputInt to RazorImGui
### Engine ###
- Added logic to OnContactAdded to handle contact points
- Added ClearContactMap to ContactListener to clear _mBodyContactMap
- Added call within JoltPhysicsEngine::Simulate to clearContactMap before running new physics frame
- Refactored CreateBoxRigidBody to take in scale of object when creating box shape and added bIsTrigger parameter to turn body into sensor rather than collider
- Added MoveKinematic function to IPhysicsInterface
- Added mCollisionPoints member to ContactInfo to hold contact points from collision
- Added CopyComponent calls for CollisionComponent & Text to Scene::Clone
- Added checks for CollisionComponent in StartScene
- Added CollisionComponent to Scene Saving/Loading
- Fixed incorrect type of System.Float changed to System.Single in ScriptField::GetType
- Fixed incorrect type of System.Int changed to System.Int32 in ScriptField::GetType
- Added hitPoint handling to Collision_GetEvent in ScriptGlue
- Added function to ScriptGlue
  - Text_SetText
  - Text_GetText
  - Text_SetColor
  - Text_SetScale
  - Scene_GetEntitiesWithText
- Fixed CollisionSystem not taking into account with OnCollisionStarted whether we had already processed the contact
- Refactored Events construction to take into account collisionPoints
- Added ability to handle movement of kinematic bodies in PhysicsSystem
- Fixed RSRenderPass bailing on rendering any Text components if one of them didn't have a font now we just continue and skip the one without a font
- Transform component now initialises Scale to (1,1,1) and uses it when calculating transform
- Collision component has new bIsTrigger member
- CollisionEvent has new mCollisionPoints member
- Engine::Step now sets LastFrame to current time if it was previously not set this fixes huge starting delta times when starting runtime
- Engine::RunRuntime on exit reset LastFrame to 0 so we don't carry over previous runtimes LastFrame again leading to a huge starting delta time
### C# API ###
- Added hitpoint arrays to Collision.cs
- Added following function mappings to InternalCalls 
  - Text_SetText
  - Text_GetText
  - Text_SetColor
  - Text_SetScale
  - Scene_GetEntitiesWithText
- Changed CollisionGetEvent to handle hitpoints
- Refactored Scene C# getting logic to handle Native & Scripting components correctly
- Added Text.cs
### Sandbox ###
- Add BaseSpeed, Direction & YDirection to Player component
- Add bounds checking and bouncing to PlayerMovement system
- Added new Score component
  - playerIndex for which player it holds score for
  - score the actual score counter
- Added new ScoreSystem
  - Updates the text component message to what the current score components score is
- Added playerIndex to TestBox component to tell which player controls it
- TestBoxBodySystem now takes in input to control movement 